### PR TITLE
auth: Move scopes to bitmask model

### DIFF
--- a/auth/scopes.go
+++ b/auth/scopes.go
@@ -1,0 +1,126 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Scopes is a bitmask representation of RBAC access. Scopes are done in groups
+// of four bits to denote Read, Update, Create, Delete. This 64-bit value gives
+// room for 16 different resources.
+type Scopes uint64
+
+const (
+	scopeR Scopes = 1 << 0
+	scopeU Scopes = 1 << 1
+	scopeC Scopes = 1 << 2
+	scopeD Scopes = 1 << 3
+
+	scopeShiftDevices Scopes = 0
+	scopeShiftUpdates Scopes = 4
+	scopeShiftUsers   Scopes = 8
+
+	ScopeDevicesR  = scopeR << scopeShiftDevices
+	ScopeDevicesRU = (scopeU | scopeR) << scopeShiftDevices
+	ScopeDevicesD  = scopeD << scopeShiftDevices
+
+	ScopeUpdatesR  = scopeR << scopeShiftUpdates
+	ScopeUpdatesRU = (scopeU | scopeR) << scopeShiftUpdates
+
+	ScopeUsersR  = scopeR << scopeShiftUsers
+	ScopeUsersRU = (scopeU | scopeR) << scopeShiftUsers
+	ScopeUsersC  = scopeC << scopeShiftUsers
+	ScopeUsersD  = scopeD << scopeShiftUsers
+)
+
+var maskToString = map[Scopes]string{
+	ScopeDevicesR:  "devices:read",
+	ScopeDevicesRU: "devices:read-update",
+	ScopeDevicesD:  "devices:delete",
+
+	ScopeUpdatesR:  "updates:read",
+	ScopeUpdatesRU: "updates:read-update",
+
+	ScopeUsersR:  "users:read",
+	ScopeUsersRU: "users:read-update",
+	ScopeUsersC:  "users:create",
+	ScopeUsersD:  "users:delete",
+}
+
+var stringToMask = map[string]Scopes{}
+var allScopes []string
+var maskInclusions = map[Scopes][]Scopes{}
+
+func init() {
+	for k, v := range maskToString {
+		stringToMask[v] = k
+		allScopes = append(allScopes, v)
+
+		// keep up with supersets. eg. read-update includes read
+		var sups []Scopes
+		for super := range maskToString {
+			if k&super == k && k != super {
+				sups = append(sups, super)
+			}
+		}
+		if len(sups) > 0 {
+			maskInclusions[k] = sups
+		}
+	}
+	sort.Strings(allScopes)
+}
+
+// ScopesAvailable returns a list of all available scopes as strings for display purposes.
+func ScopesAvailable() []string {
+	return allScopes
+}
+
+// ScopesFromString parses a comma-separated list of scopes into a Scopes bitmask.
+func ScopesFromString(scopes string) (Scopes, error) {
+	return ScopesFromSlice(strings.Split(scopes, ","))
+}
+
+// ScopesFromSlice parses a slice of scope strings into a Scopes bitmask.
+func ScopesFromSlice(scopes []string) (Scopes, error) {
+	var s Scopes
+	for _, scope := range scopes {
+		if v, ok := stringToMask[strings.TrimSpace(scope)]; ok {
+			s |= v
+		} else {
+			return 0, fmt.Errorf("invalid scope: `%s`", scope)
+		}
+	}
+	return s, nil
+}
+
+func (s Scopes) String() string {
+	return strings.Join(s.ToSlice(), ",")
+}
+
+func (s Scopes) ToSlice() []string {
+	var result []string
+OUTER:
+	for k, v := range maskToString {
+		if s&k == k {
+			if sups, ok := maskInclusions[k]; ok {
+				// Check if this mask also contains one of the "super" masks of k.
+				for _, kk := range sups {
+					if s&kk == kk {
+						continue OUTER
+					}
+				}
+			}
+			result = append(result, v)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (s Scopes) Has(scope Scopes) bool {
+	return s&scope == scope
+}

--- a/auth/scopes_test.go
+++ b/auth/scopes_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package auth_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/foundriesio/dg-satellite/auth"
+)
+
+func TestScopesFromString(t *testing.T) {
+	tests := []struct {
+		name    string // description of this test case
+		scopes  string
+		want    auth.Scopes
+		has     []auth.Scopes
+		wantErr bool
+	}{
+		{
+			name:    "Invalid resource",
+			scopes:  "device:read,users:read-update",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid scope",
+			scopes:  "devices:read,users:read-updat",
+			wantErr: true,
+		},
+		{
+			name:    "Nonexistent scope",
+			scopes:  "devices:read,updates:delete",
+			wantErr: true,
+		},
+		{
+			name:   "Handle white space",
+			scopes: "devices:read, users:read-update",
+			want:   auth.ScopeDevicesR | auth.ScopeUsersRU,
+			has:    []auth.Scopes{auth.ScopeDevicesR, auth.ScopeUsersR},
+		},
+		{
+			name:   "Normalize supersets",
+			scopes: "devices:read, devices:read-update,updates:read",
+			want:   auth.ScopeDevicesRU | auth.ScopeUpdatesR,
+			has:    []auth.Scopes{auth.ScopeDevicesR, auth.ScopeDevicesRU, auth.ScopeUpdatesR},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := auth.ScopesFromString(tt.scopes)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("ScopesFromString() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("ScopesFromString() succeeded unexpectedly")
+			}
+
+			if got != tt.want {
+				t.Errorf("ScopesFromString() = %v, want %v", got, tt.want)
+			}
+
+			for _, h := range tt.has {
+				if !got.Has(h) {
+					t.Errorf("ScopesFromString().Has(%v) = false, want true", h)
+				}
+			}
+			if got.Has(auth.ScopeDevicesD) {
+				t.Errorf("ScopesFromString().Has(devices:delete) = true, want false")
+			}
+		})
+	}
+}
+
+func TestScopes_ToSlice(t *testing.T) {
+	tests := []struct {
+		name   string // description of this test case
+		scopes auth.Scopes
+		want   []string
+	}{
+		{
+			name:   "devices:read and users:read-update",
+			scopes: auth.ScopeDevicesR | auth.ScopeUsersRU,
+			want:   []string{"devices:read", "users:read-update"},
+		},
+		{
+			name:   "devices:read, users:read, users:delete",
+			scopes: auth.ScopeDevicesR | auth.ScopeUsersR | auth.ScopeUsersD,
+			want:   []string{"devices:read", "users:delete", "users:read"},
+		},
+		{
+			name:   "users:read-update, users:create, updates:read-update",
+			scopes: auth.ScopeUsersRU | auth.ScopeUsersC | auth.ScopeUpdatesRU,
+			want:   []string{"updates:read-update", "users:create", "users:read-update"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asSlice := tt.scopes.ToSlice()
+			if !slices.Equal(asSlice, tt.want) {
+				t.Fatalf("ToSlice() = %v, want %v", asSlice, tt.want)
+			}
+
+			got, err := auth.ScopesFromSlice(asSlice)
+			if err != nil {
+				t.Fatalf("ScopesFromSlice() failed: %v", err)
+			}
+			if got != tt.scopes {
+				t.Errorf("ScopesFromSlice() = %v, want %v", got, tt.scopes)
+			}
+		})
+	}
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -7,18 +7,9 @@ import (
 	"net/http"
 )
 
-// Scope helps simplify how we check for role-based access. For example,
-// if you want to list devices you need `devices:read` *or* `devices:read-update`.
-// Scope allows us to define a "devices-list" that covers them both
-type Scope []string
-
-var ScopeDevicesR = Scope{"devices:read", "devices:read-update"}
-var ScopeDevicesRU = Scope{"devices:read-update"}
-var ScopeDevicesD = Scope{"devices:delete"}
-
 type User interface {
 	Id() string
-	HasScope(Scope) error
+	Scopes() Scopes
 }
 
 // AuthUserFunc allows us to define a generic way for middleware to do

--- a/auth/user_fake.go
+++ b/auth/user_fake.go
@@ -4,7 +4,6 @@
 package auth
 
 import (
-	"errors"
 	"net/http"
 )
 
@@ -16,11 +15,11 @@ func (fakeUser) Id() string {
 	return "fake-user"
 }
 
-func (u fakeUser) HasScope(Scope) error {
+func (u fakeUser) Scopes() Scopes {
 	if u.denyHasScope {
-		return errors.New("fakeUser has denyHashScope set")
+		return 0
 	}
-	return nil
+	return 0xFFFFFFFFFFFFFFFF
 }
 
 func FakeAuthUser(w http.ResponseWriter, r *http.Request) (User, error) {

--- a/server/ui/api/middleware.go
+++ b/server/ui/api/middleware.go
@@ -4,22 +4,19 @@
 package api
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/foundriesio/dg-satellite/auth"
 	"github.com/labstack/echo/v4"
 )
 
-func requireScope(scope auth.Scope) echo.MiddlewareFunc {
+func requireScope(scope auth.Scopes) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			user := c.Get("user").(auth.User)
-			if err := user.HasScope(scope); err != nil {
-				if err2 := c.String(http.StatusForbidden, err.Error()); err2 != nil {
-					return errors.Join(err, err2)
-				}
-				return err
+			if !user.Scopes().Has(scope) {
+				msg := "User missing required scope(s): " + scope.String()
+				return c.String(http.StatusForbidden, msg)
 			}
 			return next(c)
 		}


### PR DESCRIPTION
Doing string comparisons is becoming difficult and error prone for new code being written to manage permissions and tokens. This approach makes it easier to manage and test scopes.