### PR TITLE
storage: Make "installation applied" status generic

### DIFF
--- a/storage/models.go
+++ b/storage/models.go
@@ -47,7 +47,7 @@ func (e DeviceUpdateEvent) ParseStatus() *DeviceStatus {
 	case "EcuInstallationStarted":
 		status = "Install started"
 	case "EcuInstallationApplied":
-		status = "Install applied, waiting for reboot"
+		status = "Install applied, awaiting update finalization"
 	case "EcuInstallationCompleted":
 		if e.Event.Success != nil && !*e.Event.Success {
 			status = "Install failed"


### PR DESCRIPTION
For apps-only updates, the "installation applied" status indicates that new apps have been installed but not yet started. The existing status value, Install applied, waiting for reboot, is confusing in this case because no reboot is needed. To make the status message appropriate for both OSTree and apps-only updates, we make it more generic.