### PR TITLE
Fix issues around authentication, UI->REST_API, and CSRF

### DIFF
--- a/auth/csrf.go
+++ b/auth/csrf.go
@@ -1,0 +1,67 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+const CsrfCookieName = "dg-satellite-csrf"
+const CsrfHeaderName = "X-CSRF-Token"
+
+// SetCsrfCookie sets a CSRF cookie on the response. It should be called
+// when a new session is created. The cookie is NOT HttpOnly so that
+// JavaScript can read the value to include in request headers.
+func SetCsrfCookie(c echo.Context, expires time.Time) {
+	c.SetCookie(&http.Cookie{
+		Name:     CsrfCookieName,
+		Value:    rand.Text(),
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+// CsrfCheck is a middleware that validates the CSRF token for non-safe HTTP
+// methods (anything other than GET, HEAD, OPTIONS). It skips the check for
+// requests that use an Authorization header (i.e. API token auth).
+func CsrfCheck(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		method := c.Request().Method
+		if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
+			return next(c)
+		}
+
+		// Skip CSRF check for token-authenticated API requests
+		if c.Request().Header.Get("Authorization") != "" {
+			return next(c)
+		}
+
+		cookie, err := c.Cookie(CsrfCookieName)
+		if err != nil || cookie.Value == "" {
+			return c.String(http.StatusForbidden, "Missing CSRF cookie")
+		}
+
+		headerToken := c.Request().Header.Get(CsrfHeaderName)
+		if headerToken == "" {
+			headerToken = c.FormValue("_csrf")
+		}
+		if headerToken == "" {
+			return c.String(http.StatusForbidden, "Missing CSRF token")
+		}
+
+		if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(headerToken)) != 1 {
+			return c.String(http.StatusForbidden, "CSRF token mismatch")
+		}
+
+		return next(c)
+	}
+}

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/foundriesio/dg-satellite/storage/users"
 	"github.com/labstack/echo/v4"
@@ -64,9 +63,6 @@ func (p *commonProvider) GetSession(c echo.Context) (*Session, error) {
 		return nil, p.renderer.renderLoginPage(c, err.Error())
 	} else if len(cookie.Value) == 0 {
 		return nil, p.renderer.renderLoginPage(c, "")
-	}
-	if cookie.Expires.Before(time.Now()) {
-		return nil, p.renderer.renderLoginPage(c, "Cookie expired")
 	}
 	sessionID := cookie.Value
 	user, err := p.users.GetBySession(sessionID)

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -37,29 +38,24 @@ func (p *commonProvider) GetUser(c echo.Context) (*users.User, error) {
 	authHeader := c.Request().Header.Get("Authorization")
 	if len(authHeader) > 0 {
 		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 {
-			return nil, c.String(http.StatusUnauthorized, "invalid authorization header")
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			return nil, fmt.Errorf("invalid authorization header")
 		}
-
-		var user *users.User
-		var err error
-		if strings.ToLower(parts[0]) == "bearer" {
-			user, err = p.users.GetByToken(parts[1])
-		} else if strings.ToLower(parts[0]) == "x-internal" {
-			user, err = p.users.GetByInternalToken(parts[1])
-		} else {
-			return nil, c.String(http.StatusUnauthorized, "Unsupported authorization type")
-		}
+		user, err := p.users.GetByToken(parts[1])
 		if err != nil {
-			slog.Warn("unable to find user", "auth-type", parts[0], "error", err)
+			slog.Warn("unable to get user by token", "error", err)
 			return nil, c.String(http.StatusInternalServerError, "Could not get user by token")
 		} else if user == nil {
-			return nil, c.String(http.StatusUnauthorized, "Invalid internal token")
+			return nil, c.String(http.StatusUnauthorized, "Invalid token")
 		}
 		return user, nil
 	}
 
-	return nil, c.String(http.StatusUnauthorized, "Missing authentication")
+	session, err := p.GetSession(c)
+	if err != nil || session == nil {
+		return nil, err
+	}
+	return session.User, nil
 }
 
 func (p *commonProvider) GetSession(c echo.Context) (*Session, error) {
@@ -73,12 +69,12 @@ func (p *commonProvider) GetSession(c echo.Context) (*Session, error) {
 		return nil, p.renderer.renderLoginPage(c, "Cookie expired")
 	}
 	sessionID := cookie.Value
-	user, token, err := p.users.GetBySession(sessionID)
+	user, _, err := p.users.GetBySession(sessionID)
 	if user != nil {
 		session := &Session{
 			BaseUrl: c.Scheme() + "://" + c.Request().Host,
 			User:    user,
-			Client:  newHttpClientWithInternalToken(token),
+			Client:  newHttpClientWithSessionCookie(cookie),
 		}
 		return session, nil
 	}

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -69,7 +69,7 @@ func (p *commonProvider) GetSession(c echo.Context) (*Session, error) {
 		return nil, p.renderer.renderLoginPage(c, "Cookie expired")
 	}
 	sessionID := cookie.Value
-	user, _, err := p.users.GetBySession(sessionID)
+	user, err := p.users.GetBySession(sessionID)
 	if user != nil {
 		session := &Session{
 			BaseUrl: c.Scheme() + "://" + c.Request().Host,

--- a/auth/provider_local.go
+++ b/auth/provider_local.go
@@ -169,6 +169,7 @@ func (p *localProvider) handleLogin(c echo.Context) error {
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 	})
+	SetCsrfCookie(c, expires)
 
 	return c.Redirect(http.StatusSeeOther, "/")
 }

--- a/auth/provider_local.go
+++ b/auth/provider_local.go
@@ -181,14 +181,20 @@ func (p localProvider) renderLoginPage(c echo.Context, reason string) error {
 			"error": "authentication required",
 		})
 	}
+	var csrfToken string
+	if cookie, err := c.Cookie(CsrfCookieName); err == nil {
+		csrfToken = cookie.Value
+	}
 	context := struct {
-		Title    string
-		Reason   string
-		User     *users.User
-		NavItems []string
+		Title     string
+		Reason    string
+		User      *users.User
+		NavItems  []string
+		CsrfToken string
 	}{
-		Title:  "Login",
-		Reason: reason,
+		Title:     "Login",
+		Reason:    reason,
+		CsrfToken: csrfToken,
 	}
 	return templates.Templates.ExecuteTemplate(c.Response(), localLoginTemplate, context)
 }
@@ -223,15 +229,21 @@ func (p localProvider) GetSession(c echo.Context) (*Session, error) {
 }
 
 func (p *localProvider) handlePasswordPage(c echo.Context, session *Session) error {
+	var csrfToken string
+	if cookie, err := c.Cookie(CsrfCookieName); err == nil {
+		csrfToken = cookie.Value
+	}
 	context := struct {
-		Title    string
-		Message  string
-		User     *users.User
-		NavItems []string
+		Title     string
+		Message   string
+		User      *users.User
+		NavItems  []string
+		CsrfToken string
 	}{
-		Title:   "Change Password",
-		Message: "Your password has expired. Please choose a new password.",
-		User:    session.User,
+		Title:     "Change Password",
+		Message:   "Your password has expired. Please choose a new password.",
+		User:      session.User,
+		CsrfToken: csrfToken,
 	}
 	return templates.Templates.ExecuteTemplate(c.Response(), localPasswordChangeTemplate, context)
 }

--- a/auth/provider_oauthbase.go
+++ b/auth/provider_oauthbase.go
@@ -135,6 +135,7 @@ func (p oauth2BaseProvider) handleOauthCallback(c echo.Context) error {
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 	})
+	SetCsrfCookie(c, expires)
 
 	return c.Redirect(http.StatusTemporaryRedirect, "/")
 }

--- a/auth/provider_oauthbase.go
+++ b/auth/provider_oauthbase.go
@@ -73,18 +73,24 @@ func (p oauth2BaseProvider) renderLoginPage(c echo.Context, reason string) error
 			"error": "authentication required",
 		})
 	}
+	var csrfToken string
+	if cookie, err := c.Cookie(CsrfCookieName); err == nil {
+		csrfToken = cookie.Value
+	}
 	context := struct {
-		Title    string
-		LoginTip string
-		Name     string
-		Reason   string
-		User     *users.User
-		NavItems []string
+		Title     string
+		LoginTip  string
+		Name      string
+		Reason    string
+		User      *users.User
+		NavItems  []string
+		CsrfToken string
 	}{
-		Title:    "Login",
-		LoginTip: p.loginTip,
-		Name:     p.displayName,
-		Reason:   reason,
+		Title:     "Login",
+		LoginTip:  p.loginTip,
+		Name:      p.displayName,
+		Reason:    reason,
+		CsrfToken: csrfToken,
 	}
 	return templates.Templates.ExecuteTemplate(c.Response(), "oauth2-login.html", context)
 }

--- a/auth/transport.go
+++ b/auth/transport.go
@@ -8,21 +8,21 @@ import (
 	"net/http"
 )
 
-func newHttpClientWithInternalToken(token string) *http.Client {
+func newHttpClientWithSessionCookie(cookie *http.Cookie) *http.Client {
 	return &http.Client{
-		Transport: &roundTripper{
-			base:  http.DefaultTransport,
-			token: token,
+		Transport: &cookieRoundTripper{
+			base:   http.DefaultTransport,
+			cookie: cookie,
 		},
 	}
 }
 
-type roundTripper struct {
-	base  http.RoundTripper
-	token string
+type cookieRoundTripper struct {
+	base   http.RoundTripper
+	cookie *http.Cookie
 }
 
-func (t roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t cookieRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqBodyClosed := false
 	if req.Body != nil {
 		defer func() {
@@ -35,7 +35,7 @@ func (t roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req2 := req.Clone(req.Context())
-	req2.Header.Set("Authorization", "X-Internal "+t.token)
+	req2.AddCookie(t.cookie)
 
 	// req.Body is assumed to be closed by the base RoundTripper.
 	reqBodyClosed = true

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -22,7 +22,6 @@ var EchoError = server.EchoError
 func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
 	h := handlers{storage: storage}
 	g := e.Group("/v1")
-	g.Use(auth.CsrfCheck)
 	g.Use(authUser(a))
 
 	g.PUT("/configs", h.configsUpload, requireScope(users.ScopeDevicesRU|users.ScopeUpdatesRU),

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -22,6 +22,7 @@ var EchoError = server.EchoError
 func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
 	h := handlers{storage: storage}
 	g := e.Group("/v1")
+	g.Use(auth.CsrfCheck)
 	g.Use(authUser(a))
 
 	g.PUT("/configs", h.configsUpload, requireScope(users.ScopeDevicesRU|users.ScopeUpdatesRU),

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -144,6 +144,7 @@ func (c testClient) PUT(resource string, status int, data any, headers ...string
 
 func (c testClient) marshalHeaders(headers []string, req *http.Request) {
 	require.Zero(c.t, len(headers)%2, "Headers must be a sequence of names and values - even number")
+	req.Header.Set("Authorization", "unit-test") // needed for csrfCheck middleware to work in tests
 	for i := 0; i < len(headers)/2; i++ {
 		req.Header.Add(headers[i*2], headers[i*2+1])
 	}

--- a/server/ui/server.go
+++ b/server/ui/server.go
@@ -46,6 +46,7 @@ func NewServer(ctx context.Context, db *storage.DbHandle, fs *storage.FsHandle, 
 	daemons := daemons.New(ctx, strg, users)
 
 	srv := server.NewServer(ctx, e, serverName, port, nil)
+	e.Use(auth.CsrfCheck)
 	apiHandlers.RegisterHandlers(e, strg, provider)
 	webHandlers.RegisterHandlers(e, users, provider)
 	return &apiServer{server: srv, daemons: daemons}, nil

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -52,7 +52,6 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.GET("/updates/:prod/:tag/:name", h.updatesGet, h.requireSession, h.requireScope(users.ScopeUpdatesR))
 	e.GET("/updates/:prod/:tag/:name/tail", h.updatesTail, h.requireSession, h.requireScope(users.ScopeUpdatesR))
 	e.GET("/updates/:prod/:tag/:name/rollouts/:rollout", h.updatesRollout, h.requireSession, h.requireScope(users.ScopeUpdatesR))
-	e.PUT("/updates/:prod/:tag/:name/rollouts/:rollout", h.updatesRolloutCreate, h.requireSession, h.requireScope(users.ScopeUpdatesRU))
 	e.GET("/updates/:prod/:tag/:name/rollouts/:rollout/tail", h.updatesRolloutTail, h.requireSession, h.requireScope(users.ScopeUpdatesR))
 	e.GET("/users", h.usersList, h.requireSession, h.requireScope(users.ScopeUsersR))
 	e.DELETE("/users/:username", h.userDelete, h.requireSession, h.requireScope(users.ScopeUsersD))

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -61,16 +61,22 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 }
 
 type baseCtx struct {
-	User     *users.User
-	Title    string
-	NavItems []navItem
+	User      *users.User
+	Title     string
+	NavItems  []navItem
+	CsrfToken string
 }
 
 func (h handlers) baseCtx(c echo.Context, title, selected string) baseCtx {
+	var csrfToken string
+	if cookie, err := c.Cookie(auth.CsrfCookieName); err == nil {
+		csrfToken = cookie.Value
+	}
 	return baseCtx{
-		User:     CtxGetSession(c.Request().Context()).User,
-		Title:    title,
-		NavItems: h.genNavItems(selected),
+		User:      CtxGetSession(c.Request().Context()).User,
+		Title:     title,
+		NavItems:  h.genNavItems(selected),
+		CsrfToken: csrfToken,
 	}
 }
 

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -42,7 +42,6 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.GET("/css/:filename", h.css)
 	e.GET("/auth/logout", h.authLogout, h.requireSession)
 	e.GET("/devices", h.devicesList, h.requireSession, h.requireScope(users.ScopeDevicesR))
-	e.DELETE("/devices/:uuid", h.devicesDelete, h.requireSession, h.requireScope(users.ScopeDevicesD))
 	e.GET("/devices/:uuid", h.devicesGet, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices/:uuid/apps-states", h.devicesAppsStates, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices/:uuid/labels", h.devicesLabelsGet, h.requireSession, h.requireScope(users.ScopeDevicesR))

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -45,7 +45,6 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.GET("/devices/:uuid", h.devicesGet, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices/:uuid/apps-states", h.devicesAppsStates, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices/:uuid/labels", h.devicesLabelsGet, h.requireSession, h.requireScope(users.ScopeDevicesR))
-	e.PUT("/devices/:uuid/labels", h.devicesLabelsPut, h.requireSession, h.requireScope(users.ScopeDevicesRU))
 	e.GET("/devices/:uuid/update/:update", h.devicesUpdateGet, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/settings", h.settings, h.requireSession)
 	e.GET("/updates", h.updatesList, h.requireSession, h.requireScope(users.ScopeUpdatesR))

--- a/server/ui/web/handlers_devices.go
+++ b/server/ui/web/handlers_devices.go
@@ -31,10 +31,6 @@ func (h handlers) devicesList(c echo.Context) error {
 	return h.templates.ExecuteTemplate(c.Response(), "devices_list.html", ctx)
 }
 
-func (h handlers) devicesDelete(c echo.Context) error {
-	return proxyApi(c, "/v1/devices/"+c.Param("uuid"))
-}
-
 type ipInfo struct {
 	Hostname string `json:"hostname"`
 	IP       string `json:"local_ipv4"`

--- a/server/ui/web/handlers_devices.go
+++ b/server/ui/web/handlers_devices.go
@@ -158,8 +158,3 @@ func (h handlers) devicesLabelsGet(c echo.Context) error {
 	}
 	return h.templates.ExecuteTemplate(c.Response(), "device_labels.html", ctx)
 }
-
-func (h handlers) devicesLabelsPut(c echo.Context) error {
-	resource := "/v1/devices/" + c.Param("uuid") + "/labels"
-	return proxyApi(c, resource)
-}

--- a/server/ui/web/handlers_updates.go
+++ b/server/ui/web/handlers_updates.go
@@ -181,11 +181,6 @@ func (h handlers) updatesRollout(c echo.Context) error {
 	return h.templates.ExecuteTemplate(c.Response(), "update_rollout.html", ctx)
 }
 
-func (h handlers) updatesRolloutCreate(c echo.Context) error {
-	resource := fmt.Sprintf("/v1/updates/%s/%s/%s/rollouts/%s", c.Param("prod"), c.Param("tag"), c.Param("name"), c.Param("rollout"))
-	return proxyApi(c, resource)
-}
-
 func (h handlers) updatesTail(c echo.Context) error {
 	ctx := struct {
 		baseCtx

--- a/server/ui/web/http.go
+++ b/server/ui/web/http.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/foundriesio/dg-satellite/context"
-	"github.com/labstack/echo/v4"
 )
 
 func getJson(ctx context.Context, resource string, result any) error {
@@ -37,37 +36,4 @@ func getJson(ctx context.Context, resource string, result any) error {
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)
-}
-
-func proxyApi(c echo.Context, resource string) error {
-	s := CtxGetSession(c.Request().Context())
-
-	req, err := http.NewRequest(c.Request().Method, s.BaseUrl+resource, c.Request().Body)
-	if err != nil {
-		return err
-	}
-	for key, values := range c.Request().Header {
-		for _, v := range values {
-			req.Header.Add(key, v)
-		}
-	}
-
-	apiResp, err := s.Client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := apiResp.Body.Close(); err != nil {
-			context.CtxGetLog(c.Request().Context()).Error("unable to close response body", "error", err)
-		}
-	}()
-
-	for key, values := range apiResp.Header {
-		for _, v := range values {
-			c.Response().Header().Add(key, v)
-		}
-	}
-	c.Response().WriteHeader(apiResp.StatusCode)
-	_, err = io.Copy(c.Response(), apiResp.Body)
-	return err
 }

--- a/server/ui/web/templates/base.html
+++ b/server/ui/web/templates/base.html
@@ -5,11 +5,30 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light dark">
+    {{ if .CsrfToken }}<meta name="csrf-token" content="{{.CsrfToken}}">{{ end }}
 
     <title>{{.Title}} - Satellite Server</title>
 
     <link rel="stylesheet" href="/css/pico_min_211.css">
     <link rel="stylesheet" href="/css/style.css">
+    <script>
+    (function() {
+      const token = document.querySelector('meta[name="csrf-token"]')?.content;
+      if (token) {
+        const origFetch = window.fetch;
+        window.fetch = function(url, opts) {
+          opts = opts || {};
+          opts.headers = opts.headers || {};
+          if (opts.headers instanceof Headers) {
+            if (!opts.headers.has('X-CSRF-Token')) opts.headers.set('X-CSRF-Token', token);
+          } else {
+            if (!opts.headers['X-CSRF-Token']) opts.headers['X-CSRF-Token'] = token;
+          }
+          return origFetch.call(this, url, opts);
+        };
+      }
+    })();
+    </script>
   </head>
 
   <body>

--- a/server/ui/web/templates/device_labels.html
+++ b/server/ui/web/templates/device_labels.html
@@ -83,7 +83,7 @@
           }
         });
 
-        fetch('/devices/{{.Device.Uuid}}/labels', {
+        fetch('/v1/devices/{{.Device.Uuid}}/labels', {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',

--- a/server/ui/web/templates/devices_list.html
+++ b/server/ui/web/templates/devices_list.html
@@ -73,7 +73,7 @@ function showDeleteDialog(uuid, name) {
 }
 
 function deleteDevice(uuid) {
-  fetch('/devices/' + uuid, {
+  fetch('/v1/devices/' + uuid, {
     method: 'DELETE',
   })
   .then(async response => {

--- a/server/ui/web/templates/local-login.html
+++ b/server/ui/web/templates/local-login.html
@@ -4,6 +4,7 @@
       <h2>{{.Title}}</h2>
 
       <form method="post" action="/auth/login">
+        {{ if .CsrfToken }}<input type="hidden" name="_csrf" value="{{.CsrfToken}}">{{ end }}
         <fieldset>
           <legend><strong>Username</strong></legend>
           <input type="text" name="username" required />

--- a/server/ui/web/templates/update.html
+++ b/server/ui/web/templates/update.html
@@ -144,7 +144,7 @@
           groups: selectedGroups
         };
 
-        fetch('/updates/{{.Prod}}/{{.Tag}}/{{.Name}}/rollouts/' + document.getElementById('name').value, {
+        fetch('/v1/updates/{{.Prod}}/{{.Tag}}/{{.Name}}/rollouts/' + document.getElementById('name').value, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',

--- a/storage/db.go
+++ b/storage/db.go
@@ -150,7 +150,6 @@ func createTables(db *sql.DB) error {
 			created_at     INT,
 			expires_at     INT,
 			scopes         TEXT,
-			internal_token VARCHAR(64) NOT NULL UNIQUE,
 			FOREIGN KEY(user_id) REFERENCES user(id)
 		) WITHOUT ROWID;
 	`

--- a/storage/users/sessions.go
+++ b/storage/users/sessions.go
@@ -12,15 +12,15 @@ import (
 	"github.com/foundriesio/dg-satellite/storage"
 )
 
-func (s Storage) GetBySession(id string) (*User, string, error) {
+func (s Storage) GetBySession(id string) (*User, error) {
 	sess, err := s.stmtSessionGet.run(id)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	} else if sess == nil {
-		return nil, "", nil
+		return nil, nil
 	}
 	if sess.ExpiresAt < time.Now().Unix() {
-		return nil, "", nil
+		return nil, nil
 	}
 	u, err := s.stmtUserGetById.run(sess.UserID)
 	if u != nil {
@@ -28,7 +28,7 @@ func (s Storage) GetBySession(id string) (*User, string, error) {
 		u.AllowedScopes = sess.Scopes & u.AllowedScopes
 	}
 
-	return u, sess.InternalToken, err
+	return u, err
 }
 
 func (u User) CreateSession(remoteIP string, expires int64, scopes Scopes) (string, error) {
@@ -36,8 +36,7 @@ func (u User) CreateSession(remoteIP string, expires int64, scopes Scopes) (stri
 		return "", fmt.Errorf("requested scopes %s exceed allowed scopes %s", scopes.String(), u.AllowedScopes.String())
 	}
 	idStr := rand.Text()
-	internalToken := rand.Text()
-	if err := u.h.stmtSessionCreate.run(u, idStr, internalToken, remoteIP, time.Now().Unix(), expires, scopes); err != nil {
+	if err := u.h.stmtSessionCreate.run(u, idStr, remoteIP, time.Now().Unix(), expires, scopes); err != nil {
 		return "", fmt.Errorf("unable to create session: %w", err)
 	}
 
@@ -56,28 +55,26 @@ func (u User) DeleteSession(id string) error {
 }
 
 type session struct {
-	UserID        int64
-	RemoteIP      string
-	ExpiresAt     int64
-	Scopes        Scopes
-	InternalToken string
+	UserID    int64
+	RemoteIP  string
+	ExpiresAt int64
+	Scopes    Scopes
 }
 
 type stmtSessionCreate storage.DbStmt
 
 func (s *stmtSessionCreate) Init(db storage.DbHandle) (err error) {
 	s.Stmt, err = db.Prepare("sessionCreate", `
-		INSERT INTO session (id, user_id, internal_token, remote_ip, created_at, expires_at, scopes)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO session (id, user_id, remote_ip, created_at, expires_at, scopes)
+		VALUES (?, ?, ?, ?, ?, ?)`,
 	)
 	return
 }
 
-func (s *stmtSessionCreate) run(u User, id, internalToken, remoteIP string, created, expires int64, scopes Scopes) error {
+func (s *stmtSessionCreate) run(u User, id, remoteIP string, created, expires int64, scopes Scopes) error {
 	_, err := s.Stmt.Exec(
 		id,
 		u.id,
-		internalToken,
 		remoteIP,
 		created,
 		expires,
@@ -120,7 +117,7 @@ type stmtSessionGet storage.DbStmt
 
 func (s *stmtSessionGet) Init(db storage.DbHandle) (err error) {
 	s.Stmt, err = db.Prepare("sessionGet", `
-		SELECT user_id, internal_token, remote_ip, expires_at, scopes
+		SELECT user_id, expires_at, scopes
 		FROM session
 		WHERE id = ?`,
 	)
@@ -132,8 +129,6 @@ func (s *stmtSessionGet) run(id string) (*session, error) {
 	var scopesStr string
 	err := s.Stmt.QueryRow(id).Scan(
 		&sess.UserID,
-		&sess.InternalToken,
-		&sess.RemoteIP,
 		&sess.ExpiresAt,
 		&scopesStr,
 	)

--- a/storage/users/sessions.go
+++ b/storage/users/sessions.go
@@ -31,25 +31,6 @@ func (s Storage) GetBySession(id string) (*User, string, error) {
 	return u, sess.InternalToken, err
 }
 
-func (s Storage) GetByInternalToken(token string) (*User, error) {
-	sess, err := s.stmtUserGetByInternalToken.run(token)
-	if err != nil {
-		return nil, err
-	} else if sess == nil {
-		return nil, nil
-	}
-	if sess.ExpiresAt < time.Now().Unix() {
-		return nil, nil
-	}
-	u, err := s.stmtUserGetById.run(sess.UserID)
-	if u != nil {
-		u.h = s
-		u.AllowedScopes = sess.Scopes & u.AllowedScopes
-	}
-
-	return u, err
-}
-
 func (u User) CreateSession(remoteIP string, expires int64, scopes Scopes) (string, error) {
 	if scopes&u.AllowedScopes != scopes {
 		return "", fmt.Errorf("requested scopes %s exceed allowed scopes %s", scopes.String(), u.AllowedScopes.String())
@@ -152,39 +133,6 @@ func (s *stmtSessionGet) run(id string) (*session, error) {
 	err := s.Stmt.QueryRow(id).Scan(
 		&sess.UserID,
 		&sess.InternalToken,
-		&sess.RemoteIP,
-		&sess.ExpiresAt,
-		&scopesStr,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	} else {
-		sess.Scopes, err = ScopesFromString(scopesStr)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse scopes: %w", err)
-		}
-	}
-	return &sess, nil
-}
-
-type stmtUserGetByInternalToken storage.DbStmt
-
-func (s *stmtUserGetByInternalToken) Init(db storage.DbHandle) (err error) {
-	s.Stmt, err = db.Prepare("sessionGetByInternalToken", `
-		SELECT user_id, remote_ip, expires_at, scopes
-		FROM session
-		WHERE internal_token = ?`,
-	)
-	return
-}
-
-func (s *stmtUserGetByInternalToken) run(token string) (*session, error) {
-	var sess session
-	var scopesStr string
-	err := s.Stmt.QueryRow(token).Scan(
-		&sess.UserID,
 		&sess.RemoteIP,
 		&sess.ExpiresAt,
 		&scopesStr,

--- a/storage/users/sessions.go
+++ b/storage/users/sessions.go
@@ -4,7 +4,9 @@
 package users
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"time"
@@ -12,8 +14,24 @@ import (
 	"github.com/foundriesio/dg-satellite/storage"
 )
 
+func (s Storage) hashSessionID(id string) (string, error) {
+	key, err := s.genTokenKey(id)
+	if err != nil {
+		return "", err
+	}
+	hasher := hmac.New(sha256.New, key)
+	if _, err := hasher.Write([]byte(id)); err != nil {
+		return "", fmt.Errorf("unable to hash session id: %w", err)
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
 func (s Storage) GetBySession(id string) (*User, error) {
-	sess, err := s.stmtSessionGet.run(id)
+	hashed, err := s.hashSessionID(id)
+	if err != nil {
+		return nil, err
+	}
+	sess, err := s.stmtSessionGet.run(hashed)
 	if err != nil {
 		return nil, err
 	} else if sess == nil {
@@ -36,7 +54,11 @@ func (u User) CreateSession(remoteIP string, expires int64, scopes Scopes) (stri
 		return "", fmt.Errorf("requested scopes %s exceed allowed scopes %s", scopes.String(), u.AllowedScopes.String())
 	}
 	idStr := rand.Text()
-	if err := u.h.stmtSessionCreate.run(u, idStr, remoteIP, time.Now().Unix(), expires, scopes); err != nil {
+	hashed, err := u.h.hashSessionID(idStr)
+	if err != nil {
+		return "", fmt.Errorf("unable to hash session id: %w", err)
+	}
+	if err := u.h.stmtSessionCreate.run(u, hashed, remoteIP, time.Now().Unix(), expires, scopes); err != nil {
 		return "", fmt.Errorf("unable to create session: %w", err)
 	}
 
@@ -46,7 +68,11 @@ func (u User) CreateSession(remoteIP string, expires int64, scopes Scopes) (stri
 }
 
 func (u User) DeleteSession(id string) error {
-	if err := u.h.stmtSessionDelete.run(id); err != nil {
+	hashed, err := u.h.hashSessionID(id)
+	if err != nil {
+		return fmt.Errorf("unable to hash session id: %w", err)
+	}
+	if err := u.h.stmtSessionDelete.run(hashed); err != nil {
 		return fmt.Errorf("unable to delete session: %w", err)
 	}
 	msg := fmt.Sprintf("Session deleted id=%s", id)

--- a/storage/users/user_storage.go
+++ b/storage/users/user_storage.go
@@ -54,12 +54,11 @@ type Storage struct {
 
 	hmacSecret []byte
 
-	stmtUserCreate             stmtUserCreate
-	stmtUserGetById            stmtUserGetById
-	stmtUserGetByInternalToken stmtUserGetByInternalToken
-	stmtUserGetByName          stmtUserGetByName
-	stmtUserList               stmtUserList
-	stmtUserUpdate             stmtUserUpdate
+	stmtUserCreate    stmtUserCreate
+	stmtUserGetById   stmtUserGetById
+	stmtUserGetByName stmtUserGetByName
+	stmtUserList      stmtUserList
+	stmtUserUpdate    stmtUserUpdate
 
 	stmtSessionCreate        stmtSessionCreate
 	stmtSessionDelete        stmtSessionDelete
@@ -88,7 +87,6 @@ func NewStorage(db *storage.DbHandle, fs *storage.FsHandle) (*Storage, error) {
 	if err := db.InitStmt(
 		&handle.stmtUserCreate,
 		&handle.stmtUserGetById,
-		&handle.stmtUserGetByInternalToken,
 		&handle.stmtUserGetByName,
 		&handle.stmtUserList,
 		&handle.stmtUserUpdate,

--- a/storage/users/user_storage_test.go
+++ b/storage/users/user_storage_test.go
@@ -216,7 +216,7 @@ func TestGc(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, tokens, 0)
 
-	u2, _, err := users.GetBySession(session)
+	u2, err := users.GetBySession(session)
 	require.Nil(t, err)
 	require.Nil(t, u2)
 }


### PR DESCRIPTION
I've done a couple of things dealing with how the web ui should talk to the backend API. This set of changes:

 * reverts all the original changes
 * stops storing the web session ID in clear text in the db
 * fixes our cookie expiration logic .. again
 * Adds comprehensive CSRF protection

The CSRF protection commit is the main thing to look at. It:
 * sends a cookie with each session that has the CSRF token
 * checks during REST APIs for cookie auth and if the caller provides the CSRF token