### PR TITLE
ui: Handle TUF issues gracefully in updates view

### DIFF
--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -1002,9 +1002,11 @@ func TestApiUploadConfigs(t *testing.T) {
 func TestApiUpdateCreate(t *testing.T) {
 	tc := NewTestClient(t)
 
+	validTargets := `{"signed": {"targets": {"foo": {"custom": {"tags": ["main"]}}}}}`
+
 	validTar := tarBuffer(t, map[string]string{
 		"tuf/root.json":              `{"signed":{}}`,
-		"tuf/targets.json":           `{"signed":{}}`,
+		"tuf/targets.json":           validTargets,
 		"ostree_repo/config":         "[core]\nrepo_version=1\n",
 		"ostree_repo/refs/heads/foo": "abc123",
 	})
@@ -1031,7 +1033,7 @@ func TestApiUpdateCreate(t *testing.T) {
 	// Valid tar with tuf + apps (no ostree_repo)
 	appsTar := tarBuffer(t, map[string]string{
 		"tuf/root.json":    `{"signed":{}}`,
-		"tuf/targets.json": `{"signed":{}}`,
+		"tuf/targets.json": validTargets,
 		"apps/myapp.json":  `{"name":"myapp"}`,
 	})
 	tc.POST("/updates/prod/main/v2.0", 201, bytes.NewReader(appsTar.Bytes()),
@@ -1044,10 +1046,23 @@ func TestApiUpdateCreate(t *testing.T) {
 	// Valid tar with tuf + ostree_repo + apps (both present)
 	bothTar := tarBuffer(t, map[string]string{
 		"tuf/root.json":      `{"signed":{}}`,
+		"tuf/targets.json":   validTargets,
 		"ostree_repo/config": "[core]\n",
 		"apps/myapp.json":    `{}`,
 	})
 	tc.POST("/updates/ci/main/v3.0", 201, bytes.NewReader(bothTar.Bytes()),
+		"Content-Type", "application/x-tar")
+
+	// Valid tar with tuf + ostree_repo + apps (both present)
+	// BUT - targets.json has invalid tag. An update for "main" isn't going to work if the update
+	// doesn't have a target with tagged with "main"
+	bothTar = tarBuffer(t, map[string]string{
+		"tuf/root.json":      `{"signed":{}}`,
+		"tuf/targets.json":   `{"signed": {"targets": {"foo": {"custom": {"tags": ["invalid"]}}}}}`,
+		"ostree_repo/config": "[core]\n",
+		"apps/myapp.json":    `{}`,
+	})
+	tc.POST("/updates/ci/main/v3.1", 400, bytes.NewReader(bothTar.Bytes()),
 		"Content-Type", "application/x-tar")
 
 	// Missing tuf directory
@@ -1069,6 +1084,7 @@ func TestApiUpdateCreate(t *testing.T) {
 	// Gzip-compressed tar via Content-Type
 	gzTar := gzipBuffer(t, tarBuffer(t, map[string]string{
 		"tuf/root.json":      `{"signed":{}}`,
+		"tuf/targets.json":   validTargets,
 		"ostree_repo/config": "[core]\n",
 	}))
 	tc.POST("/updates/ci/main/v4.0", 201, bytes.NewReader(gzTar.Bytes()),
@@ -1079,6 +1095,7 @@ func TestApiUpdateCreate(t *testing.T) {
 	// Gzip-compressed tar via Content-Encoding header
 	gzTar2 := gzipBuffer(t, tarBuffer(t, map[string]string{
 		"tuf/root.json":      `{"signed":{}}`,
+		"tuf/targets.json":   validTargets,
 		"ostree_repo/config": "[core]\n",
 	}))
 	tc.POST("/updates/ci/main/v5.0", 201, bytes.NewReader(gzTar2.Bytes()),

--- a/server/ui/web/handlers_updates.go
+++ b/server/ui/web/handlers_updates.go
@@ -123,8 +123,9 @@ func (h handlers) updatesGet(c echo.Context) error {
 
 	url = fmt.Sprintf("/v1/updates/%s/%s/%s/tuf", c.Param("prod"), c.Param("tag"), c.Param("name"))
 	var tuf api.UpdateTufResp
+	tufErr := ""
 	if err := getJson(c.Request().Context(), url, &tuf); err != nil {
-		return h.handleUnexpected(c, err)
+		tufErr = "Unable to look up the TUF metadata"
 	}
 	tufJson, err := json.MarshalIndent(tuf, "", "  ")
 	if err != nil {
@@ -141,6 +142,7 @@ func (h handlers) updatesGet(c echo.Context) error {
 		Tuf          api.UpdateTufResp
 		TufJson      string
 		LatestTarget *latestTarget
+		TufError     string
 	}{
 		baseCtx:      h.baseCtx(c, "Update Details", "updates"),
 		Tag:          c.Param("tag"),
@@ -151,6 +153,7 @@ func (h handlers) updatesGet(c echo.Context) error {
 		Tuf:          tuf,
 		TufJson:      string(tufJson),
 		LatestTarget: findLatestTarget(tuf),
+		TufError:     tufErr,
 	}
 	return h.templates.ExecuteTemplate(c.Response(), "update.html", ctx)
 }

--- a/server/ui/web/templates/update.html
+++ b/server/ui/web/templates/update.html
@@ -52,78 +52,82 @@
       </dialog>
     </section>
 
-    <section class="content-section">
-      <h2>TUF Metadata</h3>
-      <div class="grid">
-        <div>
-          <fieldset>
-            <legend><strong>Root expiration</strong></legend>
-            <p>{{index .Tuf "root.json" "signed" "expires"}}</p>
-          </fieldset>
-        </div>
-        <div>
-          <fieldset>
-            <legend><strong>Snapshot expiration</strong></legend>
-            <p>{{index .Tuf "snapshot.json" "signed" "expires"}}</p>
-          </fieldset>
-        </div>
-        <div>
-          <fieldset>
-            <legend><strong>Timestamp expiration</strong></legend>
-            <p>{{index .Tuf "timestamp.json" "signed" "expires"}}</p>
-          </fieldset>
-        </div>
-        <div>
-          <fieldset>
-            <legend><strong>Targets expiration</strong></legend>
-            <p>{{index .Tuf "targets.json" "signed" "expires"}}</p>
-          </fieldset>
-        </div>
-      </div>
-      {{ if .LatestTarget }}
-      <div class="grid">
-        <div>
-          <fieldset>
-            <legend><strong>Latest target name</strong></legend>
-            <p>{{ .LatestTarget.Name }}</p>
-          </fieldset>
-        </div>
-        <div>
-          <fieldset>
-            <legend><strong>Version</strong></legend>
-            <p>{{ .LatestTarget.Version }}</p>
-          </fieldset>
-        </div>
-        <div></div>
-        <div></div>
-      </div>
-      <div class="grid">
-        <div>
-          <fieldset>
-            <legend><strong>OSTree hash</strong></legend>
-            <p>{{ .LatestTarget.Sha256}}</p>
-          </fieldset>
-        </div>
-      </div>
-      <div class="grid">
-        <div>
-          <fieldset>
-            <legend><strong>Apps</strong></legend>
-            <dl>
-            {{ range $name, $uri := .LatestTarget.Apps }}
-              <dt>{{ $name }}</dt>
-              <dd><code>{{ $uri }}</code></dd>
-            {{ end }}
-            </dl>
-          </fieldset>
-        </div>
-      </div>
-      {{ end }}
 
-      <details>
-        <summary role="button">Raw data</summary>
-        <pre>{{ .TufJson }}</pre>
-      </details>
+    <section class="content-section">
+      <h2>TUF Metadata</h2>
+      {{ if .TufError }}
+        <div class="error-message" style="color: red; font-weight: bold;">{{ .TufError }}</div>
+      {{ else }}
+        <div class="grid">
+          <div>
+            <fieldset>
+              <legend><strong>Root expiration</strong></legend>
+              <p>{{index .Tuf "root.json" "signed" "expires"}}</p>
+            </fieldset>
+          </div>
+          <div>
+            <fieldset>
+              <legend><strong>Snapshot expiration</strong></legend>
+              <p>{{index .Tuf "snapshot.json" "signed" "expires"}}</p>
+            </fieldset>
+          </div>
+          <div>
+            <fieldset>
+              <legend><strong>Timestamp expiration</strong></legend>
+              <p>{{index .Tuf "timestamp.json" "signed" "expires"}}</p>
+            </fieldset>
+          </div>
+          <div>
+            <fieldset>
+              <legend><strong>Targets expiration</strong></legend>
+              <p>{{index .Tuf "targets.json" "signed" "expires"}}</p>
+            </fieldset>
+          </div>
+        </div>
+        {{ if .LatestTarget }}
+        <div class="grid">
+          <div>
+            <fieldset>
+              <legend><strong>Latest target name</strong></legend>
+              <p>{{ .LatestTarget.Name }}</p>
+            </fieldset>
+          </div>
+          <div>
+            <fieldset>
+              <legend><strong>Version</strong></legend>
+              <p>{{ .LatestTarget.Version }}</p>
+            </fieldset>
+          </div>
+          <div></div>
+          <div></div>
+        </div>
+        <div class="grid">
+          <div>
+            <fieldset>
+              <legend><strong>OSTree hash</strong></legend>
+              <p>{{ .LatestTarget.Sha256}}</p>
+            </fieldset>
+          </div>
+        </div>
+        <div class="grid">
+          <div>
+            <fieldset>
+              <legend><strong>Apps</strong></legend>
+              <dl>
+              {{ range $name, $uri := .LatestTarget.Apps }}
+                <dt>{{ $name }}</dt>
+                <dd><code>{{ $uri }}</code></dd>
+              {{ end }}
+              </dl>
+            </fieldset>
+          </div>
+        </div>
+        {{ end }}
+        <details>
+          <summary role="button">Raw data</summary>
+          <pre>{{ .TufJson }}</pre>
+        </details>
+      {{ end }}
     </section>
 
     <script>

--- a/storage/file_updates.go
+++ b/storage/file_updates.go
@@ -5,6 +5,7 @@ package storage
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -40,6 +41,40 @@ func (s *updatesFsHandleWrap) init(root string) {
 	s.Logs.category = UpdatesLogsDir
 }
 
+// checkUpdateTargets ensures that the update contains a valid targets.json file by looking for:
+//   - is it valid JSON?
+//   - does it have a target with the given tag
+func checkUpdateTargets(targetsPath, tag string) error {
+	content, err := os.ReadFile(targetsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("missing required targets.json file in tuf directory")
+		}
+		return fmt.Errorf("error reading targets.json: %w", err)
+	}
+
+	var targets struct {
+		Signed struct {
+			Targets map[string]struct {
+				Custom struct {
+					Tags []string `json:"tags"`
+				} `json:"custom"`
+			} `json:"targets"`
+		} `json:"signed"`
+	}
+
+	if err = json.Unmarshal(content, &targets); err != nil {
+		return fmt.Errorf("error parsing targets.json: %w", err)
+	}
+
+	for _, t := range targets.Signed.Targets {
+		if slices.Contains(t.Custom.Tags, tag) {
+			return nil
+		}
+	}
+	return fmt.Errorf("no target with tag '%s' found in targets.json", tag)
+}
+
 func (s updatesFsHandleWrap) SaveUpload(tag, update string, payload io.Reader, onCleanupFailure func(error)) error {
 	const (
 		appsDir   = UpdatesAppsDir + string(filepath.Separator)
@@ -72,6 +107,11 @@ func (s updatesFsHandleWrap) SaveUpload(tag, update string, payload io.Reader, o
 				if !sawOstree && !sawApps {
 					return fmt.Errorf("%w: must contain %q and/or %q directory",
 						ErrInvalidUpdate, UpdatesOstreeDir, UpdatesAppsDir)
+				}
+
+				path := filepath.Join(root, txDir, "unpacked/tuf/targets.json")
+				if err := checkUpdateTargets(path, tag); err != nil {
+					return fmt.Errorf("%w: %v", ErrInvalidUpdate, err)
 				}
 				return nil
 			},


### PR DESCRIPTION
I see this in my instance where I'm doing custom CI for fioup and only need a targets.json file to exist. We fail to parse *all* the TUF metadata and don't even show the content about the update.