### PR TITLE
swagger: let go mod control the swaggo/swag version properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           go-version: "1.24"
       - name: Install swag
-        run: go install github.com/swaggo/swag/cmd/swag@latest
+        run: go install github.com/swaggo/swag/cmd/swag
       - name: Generate Swagger docs
         run: make swagger
       - name: Upload Artifacts

--- a/server/gateway/doc.go
+++ b/server/gateway/doc.go
@@ -7,3 +7,7 @@
 // @BasePath /
 
 package gateway
+
+import (
+	_ "github.com/swaggo/swag"
+)

--- a/server/ui/api/doc.go
+++ b/server/ui/api/doc.go
@@ -7,3 +7,7 @@
 // @BasePath /v1
 
 package api
+
+import (
+	_ "github.com/swaggo/swag"
+)


### PR DESCRIPTION
Currently, swagger is only imported after `make swagger` command was run. Hence, depending onto the user's environment, go mod and linter may require or reject it inside go.mod. Anonymous import lets the go.mod do the dependency work properly for us.