### PR TITLE
docs: Fix incorrect statement for ratelimit configuration

### DIFF
--- a/auth/ratelimiter.go
+++ b/auth/ratelimiter.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -36,6 +37,13 @@ func NewRateLimiter(cfg storage.RateLimitConfig) *authRateLimiter {
 	if cfg.BadAuthBlockDurationSec <= 0 {
 		cfg.BadAuthBlockDurationSec = 300
 	}
+
+	slog.Info("RateLimiter initialized",
+		"attemptsPerSecond", cfg.AttemptsPerSecond,
+		"attemptsBlockDurationSec", cfg.AttemptsBlockDurationSec,
+		"badAuthLimit", cfg.BadAuthLimit,
+		"badAuthBlockDurationSec", cfg.BadAuthBlockDurationSec,
+	)
 
 	sweepAge := 2 * time.Duration(cfg.BadAuthBlockDurationSec) * time.Second
 	if alt := 2 * time.Duration(cfg.AttemptsBlockDurationSec) * time.Second; alt > sweepAge {

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -106,7 +106,7 @@ from making any authentication operations for 5 minutes when the limit
 has been reached.
 
 
-These values can be configured via `Config.RateLimitConfig`:
+These values can be configured via `Config.RateLimits`:
  * `AttemptsPerSecond` - Set this to globally rate-limit how many authentication operations (login, password change/reset) are allowed per IP per second. The default is 2. Requests will then be blocked for `AttemptsBlockDurationSec` for the given IP.
  * `AttemptsBlockDurationSec` - Set how long to block an IP that has been rate-limited by `AttemptsPerSecond`. The defaults will reject an IP for 30 seconds if it exceeds 2 authentication attempts per second.
  * `BadAuthLimit` - Track how many bad password operations are made from a given account. The default is 5. If this value is exceeded, the given IP will be blocked for `BadAuthBlockDurationSec` from performing password related operations.


### PR DESCRIPTION
Also adding a log statement to make this eaiser to spot