### PR TITLE
auth: Add csrf cookie for noauth

### DIFF
--- a/auth/noauth.go
+++ b/auth/noauth.go
@@ -8,6 +8,7 @@ package auth
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/foundriesio/dg-satellite/storage"
 	"github.com/foundriesio/dg-satellite/storage/users"
@@ -43,6 +44,10 @@ func (p noauthProvider) GetUser(c echo.Context) (*users.User, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+	cookie, err := c.Cookie(CsrfCookieName)
+	if err != nil || cookie.Value == "" {
+		SetCsrfCookie(c, time.Now().Add(24*time.Hour))
 	}
 	return user, nil
 }


### PR DESCRIPTION
We need a csrf cookie so noauth web sessions can make changes to things like device labels. This isn't really secure, but neither is noauth.

Fixes bug #159