### PR TITLE
Add support for understand a device's applied configuration

### DIFF
--- a/cli/api/configs.go
+++ b/cli/api/configs.go
@@ -6,12 +6,14 @@ package api
 import (
 	"io"
 
+	"github.com/foundriesio/dg-satellite/storage"
 	models "github.com/foundriesio/dg-satellite/storage/api"
 )
 
 type (
-	ConfigFile    = models.ConfigFile
-	ConfigFileSet = map[string]ConfigFile
+	ConfigFile     = models.ConfigFile
+	ConfigFileSet  = map[string]ConfigFile
+	AppliedConfigs = storage.AppliedConfigs
 )
 
 type ConfigsApi struct {
@@ -22,6 +24,8 @@ type SpecificConfigsApi struct {
 	api *Api
 	uri string
 }
+
+type DeviceConfigsApi struct{ SpecificConfigsApi }
 
 func (a *Api) Configs() ConfigsApi {
 	return ConfigsApi{api: a}
@@ -35,8 +39,8 @@ func (a ConfigsApi) Group(name string) SpecificConfigsApi {
 	return SpecificConfigsApi{api: a.api, uri: "/v1/configs/group/" + name}
 }
 
-func (a ConfigsApi) Device(uuid string) SpecificConfigsApi {
-	return SpecificConfigsApi{api: a.api, uri: "/v1/configs/device/" + uuid}
+func (a ConfigsApi) Device(uuid string) DeviceConfigsApi {
+	return DeviceConfigsApi{SpecificConfigsApi: SpecificConfigsApi{api: a.api, uri: "/v1/configs/device/" + uuid}}
 }
 
 func (a ConfigsApi) ListGroups() (names []string, err error) {
@@ -56,5 +60,16 @@ func (a SpecificConfigsApi) Get() (res ConfigFileSet, err error) {
 
 func (a SpecificConfigsApi) Put(configs ConfigFileSet) (err error) {
 	_, err = a.api.Put(a.uri, configs)
+	return
+}
+
+func (a DeviceConfigsApi) GetApplied() (result *AppliedConfigs, err error) {
+	var applied AppliedConfigs
+	if err = a.api.Get(a.uri+"/applied", &applied); err != nil {
+		return
+	}
+	if applied.AppliedAt != 0 {
+		result = &applied
+	}
 	return
 }

--- a/cli/subcommands/configs/applied.go
+++ b/cli/subcommands/configs/applied.go
@@ -1,0 +1,45 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package configs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/foundriesio/dg-satellite/cli/api"
+)
+
+var appliedCmd = &cobra.Command{
+	Use:   "applied <device-uuid>",
+	Short: "Show the applied configuration for a device",
+	Long: `Show the merged (factory + group + device) configuration that was most
+recently delivered to the device, along with the time it was applied.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		a := api.CtxGetApi(cmd.Context()).Configs().Device(args[0])
+		getDeviceApplied(a)
+	},
+}
+
+func init() {
+	ConfigsCmd.AddCommand(appliedCmd)
+}
+
+func getDeviceApplied(a api.DeviceConfigsApi) {
+	applied, err := a.GetApplied()
+	cobra.CheckErr(err)
+	if applied == nil {
+		fmt.Println("No configuration has been applied to this device yet.")
+		return
+	}
+	appliedAt := time.Unix(applied.AppliedAt, 0)
+	fmt.Printf("Applied at: %s\n", appliedAt.Format(time.RFC1123))
+	cfg := make(api.ConfigFileSet, len(applied.Files))
+	for k, v := range applied.Files {
+		cfg[k] = *v
+	}
+	printConfigs(cfg)
+}

--- a/cli/subcommands/configs/cmd.go
+++ b/cli/subcommands/configs/cmd.go
@@ -25,7 +25,7 @@ func addSpecificFlags(cmd *cobra.Command) {
 func getSpecificApi(cmd *cobra.Command) api.SpecificConfigsApi {
 	api := api.CtxGetApi(cmd.Context()).Configs()
 	if uuid, _ := cmd.Flags().GetString("device"); len(uuid) > 0 {
-		return api.Device(uuid)
+		return api.Device(uuid).SpecificConfigsApi
 	} else if name, _ := cmd.Flags().GetString("group"); len(name) > 0 {
 		return api.Group(name)
 	}

--- a/server/gateway/handlers_config.go
+++ b/server/gateway/handlers_config.go
@@ -71,6 +71,9 @@ func (h handlers) configGet(c echo.Context) error {
 		}
 	}
 	c.Response().Header().Set("Date", cts.Format(time.RFC1123))
+	if err := d.SaveAppliedConfigs(files); err != nil {
+		log.Warn("Failed to save applied config", "device", d.Uuid, "error", err)
+	}
 	return c.JSON(http.StatusOK, files)
 }
 

--- a/server/gateway/handlers_test.go
+++ b/server/gateway/handlers_test.go
@@ -442,8 +442,27 @@ foo = "bar"
 apps = "device"
 tags = "group"
 `)
+	beforeRequest := time.Now().Unix()
 	serverCfg := strings.Trim(string(tc.GET("/config", 200)), "\n")
 	require.Equal(t, mergedCfg, serverCfg)
+
+	// Verify that the applied config envelope was persisted.
+	raw, err := tc.fs.Devices.ReadFile(tc.uuid, storage.ConfigAppliedFile)
+	require.Nil(t, err)
+	var applied baseStorage.AppliedConfigs
+	require.Nil(t, json.Unmarshal([]byte(raw), &applied))
+	assert.GreaterOrEqual(t, applied.AppliedAt, beforeRequest)
+	assert.LessOrEqual(t, applied.AppliedAt, time.Now().Unix())
+	require.Contains(t, applied.Files, storage.ConfigSotaOverride)
+	// The merged TOML value stored in the envelope should match what the server sent.
+	assert.Equal(t, mergedCfg, fmt.Sprintf(`{"%s":{"Value":%s}}`,
+		storage.ConfigSotaOverride,
+		func() string {
+			b, e := json.Marshal(applied.Files[storage.ConfigSotaOverride].Value)
+			require.Nil(t, e)
+			return string(b)
+		}()),
+	)
 }
 
 func TestInfo(t *testing.T) {

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -34,6 +34,7 @@ func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
 	g.GET("/configs/group/:name/history", h.groupConfigsHistory, requireScope(users.ScopeDevicesR))
 	g.GET("/configs/device/:uuid", h.deviceConfigsGet, requireScope(users.ScopeDevicesR))
 	g.PUT("/configs/device/:uuid", h.deviceConfigsPut, requireScope(users.ScopeDevicesRU|users.ScopeUpdatesRU))
+	g.GET("/configs/device/:uuid/applied", h.deviceAppliedConfigsGet, requireScope(users.ScopeDevicesR))
 	g.GET("/configs/device/:uuid/history", h.deviceConfigsHistory, requireScope(users.ScopeDevicesR))
 	g.GET("/devices", h.deviceList, requireScope(users.ScopeDevicesR))
 	g.GET("/devices/:uuid", h.deviceGet, requireScope(users.ScopeDevicesR))

--- a/server/ui/api/handlers_configs.go
+++ b/server/ui/api/handlers_configs.go
@@ -18,8 +18,9 @@ import (
 )
 
 type (
-	ConfigFile    = storage.ConfigFile
-	ConfigFileSet = map[string]ConfigFile
+	ConfigFile     = storage.ConfigFile
+	ConfigFileSet  = map[string]ConfigFile
+	AppliedConfigs = storage.AppliedConfigs
 )
 
 const ConfigHistoryLimit = storage.ConfigHistoryLimit
@@ -165,6 +166,28 @@ func (h *handlers) deviceConfigsGet(c echo.Context) error {
 		} else {
 			return c.NoContent(http.StatusNoContent)
 		}
+	})
+}
+
+// @Summary Read the applied configuration last sent to a device
+// @Description Returns the merged config (factory + group + device) that was most recently
+// @Description delivered to the device, along with the Unix timestamp when it was applied.
+// @Description Requires scopes: devices:read
+// @Tags    Config
+// @Produce json
+// @Param   uuid path string true "Device UUID"
+// @Success 200 {object} AppliedConfigs
+// @Router  /configs/device/{uuid}/applied [get]
+func (h *handlers) deviceAppliedConfigsGet(c echo.Context) error {
+	return h.handleDevice(c, func(device *Device) error {
+		envelope, err := h.storage.ReadAppliedConfigs(device.Uuid)
+		if err != nil {
+			return EchoError(c, err, http.StatusInternalServerError, "Failed to read applied config")
+		}
+		if envelope == nil {
+			return c.NoContent(http.StatusNoContent)
+		}
+		return c.JSON(http.StatusOK, envelope)
 	})
 }
 

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -1178,6 +1178,48 @@ func TestApiConfigsDevice(t *testing.T) {
 	})
 }
 
+func TestApiConfigsDeviceApplied(t *testing.T) {
+	tc := NewTestClient(t)
+
+	_, err := tc.gw.DeviceCreate("foo", "pubkey1", false)
+	require.Nil(t, err)
+
+	tc.u.AllowedScopes = users.ScopeDevicesR
+
+	t.Run("No applied config yet", func(t *testing.T) {
+		tc.GET("/configs/device/foo/applied", 204)
+	})
+
+	t.Run("Inexistent device", func(t *testing.T) {
+		tc.GET("/configs/device/noo/applied", 404)
+	})
+
+	t.Run("Default user scopes", func(t *testing.T) {
+		tc.u.AllowedScopes = 0
+		tc.GET("/configs/device/foo/applied", 403)
+		tc.u.AllowedScopes = users.ScopeDevicesR
+	})
+
+	// Write an applied config as the gateway would after delivering config to a device.
+	device, err := tc.gw.DeviceGet("foo")
+	require.Nil(t, err)
+	cfg := map[string]*storage.ConfigFile{
+		"test": {Value: "hello"},
+	}
+	beforeApply := time.Now().Unix()
+	require.Nil(t, device.SaveAppliedConfigs(cfg))
+
+	t.Run("Returns applied config envelope", func(t *testing.T) {
+		body := tc.GET("/configs/device/foo/applied", 200)
+		var applied storage.AppliedConfigs
+		require.Nil(t, json.Unmarshal(body, &applied))
+		assert.GreaterOrEqual(t, applied.AppliedAt, beforeApply)
+		assert.LessOrEqual(t, applied.AppliedAt, time.Now().Unix())
+		require.Contains(t, applied.Files, "test")
+		assert.Equal(t, "hello", applied.Files["test"].Value)
+	})
+}
+
 func TestApiConfigsUpload(t *testing.T) {
 	tc := NewTestClient(t)
 

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -43,6 +43,7 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.GET("/auth/logout", h.authLogout, h.requireSession)
 	e.GET("/configs", h.configsList, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/configs/device/:uuid", h.configsDeviceItem, h.requireSession, h.requireScope(users.ScopeDevicesR))
+	e.GET("/configs/device/:uuid/applied", h.configsDeviceItemApplied, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/configs/group/:name", h.configsGroupItem, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices", h.devicesList, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/devices/:uuid", h.devicesGet, h.requireSession, h.requireScope(users.ScopeDevicesR))

--- a/server/ui/web/handlers_configs.go
+++ b/server/ui/web/handlers_configs.go
@@ -5,8 +5,10 @@ package web
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/foundriesio/dg-satellite/server/ui/api"
+	storage "github.com/foundriesio/dg-satellite/storage"
 	"github.com/labstack/echo/v4"
 )
 
@@ -70,4 +72,33 @@ func (h handlers) configsDeviceItem(c echo.Context) error {
 	}
 	return h.templates.ExecuteTemplate(c.Response(), "configs_item.html", ctx)
 
+}
+
+func (h handlers) configsDeviceItemApplied(c echo.Context) error {
+	uuid := c.Param("uuid")
+	var applied storage.AppliedConfigs
+	if err := getJson(c.Request().Context(), "/v1/configs/device/"+uuid+"/applied", &applied); err != nil {
+		return h.handleUnexpected(c, err)
+	}
+
+	var configs api.ConfigFileSet
+	var appliedAt string
+	if applied.AppliedAt != 0 {
+		configs = make(api.ConfigFileSet, len(applied.Files))
+		for k, v := range applied.Files {
+			configs[k] = *v
+		}
+		appliedAt = time.Unix(applied.AppliedAt, 0).UTC().Format(time.RFC1123)
+	}
+
+	ctx := struct {
+		baseCtx
+		Configs   api.ConfigFileSet
+		AppliedAt string
+	}{
+		baseCtx:   h.baseCtx(c, fmt.Sprintf("Device \"%s\" Applied Config", uuid), "devices"),
+		Configs:   configs,
+		AppliedAt: appliedAt,
+	}
+	return h.templates.ExecuteTemplate(c.Response(), "configs_item.html", ctx)
 }

--- a/server/ui/web/templates/configs_item.html
+++ b/server/ui/web/templates/configs_item.html
@@ -34,6 +34,11 @@
 {{ template "header" .}}
     <section class="content-section">
       <h2>{{.Title}}</h2>
+      {{ if .AppliedAt }}<p>Applied at: <strong>{{ .AppliedAt }}</strong></p>{{ end }}
+      {{ if .Configs }}
       {{ template "configs-item" .Configs }}
+      {{ else }}
+      <p><em>No configuration has been applied to this device yet.</em></p>
+      {{ end }}
     </section>
 {{ template "footer"}}

--- a/server/ui/web/templates/device.html
+++ b/server/ui/web/templates/device.html
@@ -103,6 +103,7 @@
             <dd>
               <button onclick="location.href='/devices/{{.Device.Uuid}}/apps-states';">Apps States</button>
               <button onclick="location.href='/configs/device/{{.Device.Uuid}}';">Configs</button>
+              <button onclick="location.href='/configs/device/{{.Device.Uuid}}/applied';">Applied Configs</button>
               <button onclick="location.href='/devices/{{.Device.Uuid}}/tests';">Tests</button>
             </dd>
           </dl>

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -25,6 +25,7 @@ type (
 
 	AppsStates        = storage.AppsStates
 	ConfigFile        = storage.ConfigFile
+	AppliedConfigs    = storage.AppliedConfigs
 	DeviceStatus      = storage.DeviceStatus
 	DeviceUpdateEvent = storage.DeviceUpdateEvent
 
@@ -299,6 +300,21 @@ func (s Storage) DeviceGet(uuid string) (*Device, error) {
 	}
 
 	return &d, nil
+}
+
+func (s Storage) ReadAppliedConfigs(uuid string) (*storage.AppliedConfigs, error) {
+	raw, err := s.fs.Devices.ReadFile(uuid, storage.ConfigAppliedFile)
+	if err != nil {
+		return nil, err
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	var applied storage.AppliedConfigs
+	if err := json.Unmarshal([]byte(raw), &applied); err != nil {
+		return nil, fmt.Errorf("failed to parse applied config: %w", err)
+	}
+	return &applied, nil
 }
 
 var clearingEventTypes = []string{"EcuInstallationCompleted", "CertRotationCompleted", "MetadataUpdateCompleted"}

--- a/storage/file.go
+++ b/storage/file.go
@@ -46,6 +46,7 @@ const (
 	ConfigSotaOverride = "z-50-fioctl.toml"
 
 	// Per device files/dirs
+	ConfigAppliedFile   = "config-applied"
 	AktomlFile          = "aktoml"
 	HwInfoFile          = "hardware-info"
 	NetInfoFile         = "network-info"

--- a/storage/gateway/storage.go
+++ b/storage/gateway/storage.go
@@ -37,9 +37,10 @@ const (
 	CertsTlsPemFile = storage.CertsTlsPemFile
 
 	// Per device files/dirs
-	AktomlFile  = storage.AktomlFile
-	HwInfoFile  = storage.HwInfoFile
-	NetInfoFile = storage.NetInfoFile
+	ConfigAppliedFile = storage.ConfigAppliedFile
+	AktomlFile        = storage.AktomlFile
+	HwInfoFile        = storage.HwInfoFile
+	NetInfoFile       = storage.NetInfoFile
 
 	EventsPrefix = storage.EventsPrefix
 	StatesPrefix = storage.StatesPrefix
@@ -156,6 +157,18 @@ func (d Device) GetAppsFilePath(file string) string {
 	} else {
 		return d.storage.fs.Updates.Ci.Apps.FilePath(d.Tag, d.UpdateName, file)
 	}
+}
+
+func (d Device) SaveAppliedConfigs(files map[string]*storage.ConfigFile) error {
+	envelope := storage.AppliedConfigs{
+		AppliedAt: time.Now().Unix(),
+		Files:     files,
+	}
+	bytes, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	return d.storage.fs.Devices.WriteFile(d.Uuid, storage.ConfigAppliedFile, string(bytes))
 }
 
 func (d Device) GetOstreeFilePath(file string) string {

--- a/storage/models.go
+++ b/storage/models.go
@@ -46,6 +46,13 @@ type ConfigFile struct {
 	OnChanged   []string `json:"OnChanged,omitempty"`
 }
 
+// AppliedConfigs wraps the merged config sent to a device along with
+// the Unix timestamp (seconds) at which it was delivered.
+type AppliedConfigs struct {
+	AppliedAt int64                  `json:"applied_at"`
+	Files     map[string]*ConfigFile `json:"config"`
+}
+
 var evtIdToStatus = map[string]string{
 	"MetadataUpdateCompleted":  "Metadata update completed",
 	"EcuDownloadStarted":       "Download started",


### PR DESCRIPTION
@vkhoroz  - this is kind of a wild departure from how we do this in our product now, but I think this might have saved us a bunch of support issues over the years. It saves the exact config sent to a device so that you can understand what it has rather the interpolating it via a series of mental merges of config maps. It's slightly wasteful in terms of disk space, but I'm on the verge of being at peace with that considering the utility/observability this brings.

Consider this RFC. I just had Claude do it while you were reviewing my other PR