### PR TITLE
db: Enable WAL and busy timeout

### DIFF
--- a/storage/db.go
+++ b/storage/db.go
@@ -36,10 +36,16 @@ func NewDb(dbfile string) (*DbHandle, error) {
 	if _, err := os.Stat(dbfile); err != nil {
 		newDb = errors.Is(err, os.ErrNotExist)
 	}
-	db, err := sql.Open("sqlite3", dbfile)
+	// _busy_timeout: retry for up to 5s instead of immediately returning SQLITE_BUSY.
+	// _journal_mode=WAL: allows concurrent readers while a write is in progress.
+	dsn := dbfile + "?_busy_timeout=5000&_journal_mode=WAL"
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, err
 	}
+	// A single writer connection prevents writer-vs-writer lock contention.
+	// Readers share the WAL file and are not blocked by this limit.
+	db.SetMaxOpenConns(1)
 	if newDb {
 		if err := createTables(db); err != nil {
 			return nil, err


### PR DESCRIPTION
These are common sqlite flags that can really improve scaling. Running device registration tests with Locust it started at:

5000 devices / spawn rate 20
----------------------------
 NO WAL
 * 2915 failures
 * 132 requests per second

 WITH WAL and BUSYTIMEOUT
 * 0 failures
 * 297 requests per second
 * 310ms average response time (99% - 690ms)

5000 devices / spawn rate 80
----------------------------
 WITH WAL and BUSYTIMEOUT
 * 0 failures
 * 380 requests per second
 * 670ms average response time (99% - 1900)