### PR TITLE
chore: align JSON properties of AppliedConfigs with those of ConfigsFileSet

### DIFF
--- a/storage/models.go
+++ b/storage/models.go
@@ -58,8 +58,8 @@ type ConfigFileSet struct {
 // AppliedConfigs wraps the merged config sent to a device along with
 // the Unix timestamp (seconds) at which it was delivered.
 type AppliedConfigs struct {
-	Files     map[string]ConfigFile `json:"config"`
-	AppliedAt int64                 `json:"applied_at"`
+	Files     map[string]ConfigFile `json:"Files"`
+	AppliedAt int64                 `json:"AppliedAt"`
 }
 
 var evtIdToStatus = map[string]string{


### PR DESCRIPTION
In FoundriesFactory we use Hungarian notation for configs. So, I decided to preserve that for the Satellite server. An AppliedConfigs is special, but it is still nicer to follow the same notation for it.