### PR TITLE
chore: use bool instead of bool pointer for ConfigFile.Unencrypted

### DIFF
--- a/cli/subcommands/configs/set.go
+++ b/cli/subcommands/configs/set.go
@@ -83,7 +83,6 @@ func setConfigs(capi api.SpecificConfigsApi, files []string, raw, replace bool, 
 		err  error
 	)
 	cfg.Reason = reason
-	unencrypted := true
 	if raw {
 		if raw && len(files) != 1 {
 			return errors.New("raw file only accepts one file argument")
@@ -112,7 +111,7 @@ func setConfigs(capi api.SpecificConfigsApi, files []string, raw, replace bool, 
 				cobra.CheckErr(err)
 				content = string(data)
 			}
-			cfg.Files[name] = api.ConfigFile{Value: content, Unencrypted: &unencrypted}
+			cfg.Files[name] = api.ConfigFile{Value: content, Unencrypted: true}
 		}
 	}
 	if !replace {

--- a/cli/subcommands/configs/show.go
+++ b/cli/subcommands/configs/show.go
@@ -58,7 +58,7 @@ func printConfigs(cfg map[string]api.ConfigFile) {
 		} else {
 			fmt.Printf("\t%s - %v\n", name, file.OnChanged)
 		}
-		if file.Unencrypted != nil && *file.Unencrypted {
+		if file.Unencrypted {
 			for _, line := range strings.Split(file.Value, "\n") {
 				fmt.Printf("\t | %s\n", line)
 			}

--- a/cli/subcommands/configs/updates.go
+++ b/cli/subcommands/configs/updates.go
@@ -122,10 +122,9 @@ func setUpdates(capi api.SpecificConfigsApi, apps, tag, reason string) {
 		fmt.Println("No changes found.")
 		return
 	}
-	unencrypted := true
 	cfg.Files[sotaOverride] = api.ConfigFile{
 		Value:       newSotaContent,
-		Unencrypted: &unencrypted,
+		Unencrypted: true,
 		OnChanged:   []string{sotaOverrideOnChanged},
 	}
 	cobra.CheckErr(capi.Put(api.ConfigFileSet{Files: cfg.Files, Reason: reason}))

--- a/server/ui/web/templates/configs_item.html
+++ b/server/ui/web/templates/configs_item.html
@@ -9,7 +9,7 @@
                {{ if gt (len $val.OnChanged) 0 }}
                <i class="icontip ocr-fork" aria-label="On-change triggers:{{ range $val.OnChanged }}&#xa;{{.}}{{ end }}"></i>
                {{ end }}
-               {{ if deref $val.Unencrypted }}
+               {{ if $val.Unencrypted }}
                <i class="icontip floppy" aria-label="View file content"
 		  onclick="event.preventDefault();this.nextElementSibling.showModal()"></i>
                <dialog class="file-content">

--- a/server/ui/web/templates/templates.go
+++ b/server/ui/web/templates/templates.go
@@ -6,7 +6,6 @@ package templates
 import (
 	"embed"
 	"html/template"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -27,13 +26,6 @@ func init() {
 			return a - b
 		},
 		"contains": strings.Contains,
-		"deref": func(v any) any {
-			// Used to convert e.g. *bool to bool in config_item.html.
-			if val := reflect.ValueOf(v); val.Kind() == reflect.Pointer && !val.IsNil() {
-				return val.Elem().Interface()
-			}
-			return v
-		},
 	}
 
 	Templates = template.Must(template.New("").Funcs(funcMap).ParseFS(Assets, "*.html", "*.css"))

--- a/storage/models.go
+++ b/storage/models.go
@@ -42,7 +42,7 @@ type DeviceStatus struct {
 
 type ConfigFile struct {
 	Value       string   `json:"Value"`
-	Unencrypted *bool    `json:"Unencrypted,omitempty"`
+	Unencrypted bool     `json:"Unencrypted,omitempty"`
 	OnChanged   []string `json:"OnChanged,omitempty"`
 }
 


### PR DESCRIPTION
A pointer type was copied from the device gateway. But, a value type with omitempty behaves just as well; allowing for a simpler code.