### PR TITLE
feat: manage deleted devices (list + restore)

### DIFF
--- a/cli/api/devices.go
+++ b/cli/api/devices.go
@@ -90,6 +90,17 @@ func (d DeviceApi) Delete(uuid string) error {
 	return d.api.Delete(fmt.Sprintf("/v1/devices/%s", uuid))
 }
 
+// ListDenied returns all UUIDs on the denied list.
+func (d DeviceApi) ListDenied() ([]string, error) {
+	var uuids []string
+	return uuids, d.api.Get("/v1/denied-devices", &uuids)
+}
+
+// DeleteDenied removes a device from the denied list so it can access the backend again.
+func (d DeviceApi) DeleteDenied(uuid string) error {
+	return d.api.Delete(fmt.Sprintf("/v1/denied-devices/%s", uuid))
+}
+
 func (d *DeviceApi) Tests(uuid string) ([]TargetTest, error) {
 	var tests []TargetTest
 	return tests, d.api.Get(fmt.Sprintf("/v1/devices/%s/tests", uuid), &tests)

--- a/cli/subcommands/devices/delete_denied.go
+++ b/cli/subcommands/devices/delete_denied.go
@@ -1,0 +1,27 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package devices
+
+import (
+	"github.com/foundriesio/update-server/cli/api"
+	"github.com/spf13/cobra"
+)
+
+var deleteDeniedCmd = &cobra.Command{
+	Use:   "delete-denied <uuid>",
+	Short: "Remove a device from the denied list",
+	Long: `Remove a device from the denied list so it can access the backend again.
+Only the server record is affected; device data (configs, update events,
+apps states) removed when the device was denied is not recovered.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		a := api.CtxGetApi(cmd.Context())
+		cobra.CheckErr(a.Devices().DeleteDenied(args[0]))
+		return nil
+	},
+}
+
+func init() {
+	DevicesCmd.AddCommand(deleteDeniedCmd)
+}

--- a/cli/subcommands/devices/list_denied.go
+++ b/cli/subcommands/devices/list_denied.go
@@ -1,0 +1,36 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package devices
+
+import (
+	"fmt"
+
+	"github.com/foundriesio/update-server/cli/api"
+	"github.com/spf13/cobra"
+)
+
+var listDeniedCmd = &cobra.Command{
+	Use:   "list-denied",
+	Short: "List denied devices",
+	Long: `List devices on the denied list. A denied device is prevented from
+accessing the backend via mTLS. Use 'devices delete-denied' to remove a
+device from the list and allow it back.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		a := api.CtxGetApi(cmd.Context())
+		listDeniedDevices(a.Devices())
+		return nil
+	},
+}
+
+func init() {
+	DevicesCmd.AddCommand(listDeniedCmd)
+}
+
+func listDeniedDevices(dapi api.DeviceApi) {
+	uuids, err := dapi.ListDenied()
+	cobra.CheckErr(err)
+	for _, uuid := range uuids {
+		fmt.Println(uuid)
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,3 +19,29 @@ REST API, `api_swagger.yaml`, and the device gateway API,
 `gateway_swagger.yaml`. They are available [here](https://github.com/foundriesio/update-server/releases/latest)
 
 They can also be generated from source by running `make swagger`.
+
+## Denied devices
+
+Deleting a device (`DELETE /devices/{uuid}`) adds it to the denied list: the
+device record is retained in the database so the backend can reject further
+mTLS connections from that UUID/pubkey pair. Two endpoints manage this list:
+
+ * `GET /denied-devices` returns a JSON array of UUIDs currently on the denied
+   list. Requires the `devices:read` scope.
+ * `DELETE /denied-devices/{uuid}` removes a device from the denied list,
+   allowing it to connect again. Returns 404 if the device is not on the
+   denied list. Requires the `devices:delete` scope.
+
+***NOTE***: Removing a device from the denied list recovers its server record
+only. The device's stored data (configs, update events, and apps states) is
+destroyed when the device is deleted and is **not** recovered.
+
+***NOTE***: Order of operations matters when a device's key changes. The server
+record retains the public key the device had when it was added to the denied
+list, and the gateway does not currently support key rotation. So a device that
+regenerates its keypair while denied (for example after a factory reset) cannot
+be brought back via `DELETE /denied-devices/{uuid}`: once removed from the
+denied list it presents a new key that no longer matches the stored one, and the
+gateway rejects its connections. Because the record still exists, the gateway
+will also not auto-enrol it afresh. Such a device must instead be fully deleted
+and re-enrolled from scratch under a new connection.

--- a/server/gateway/middleware.go
+++ b/server/gateway/middleware.go
@@ -43,7 +43,7 @@ func (h handlers) authDevice(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 			log.Info("Created device")
 		} else if device.Deleted {
-			return c.String(http.StatusForbidden, fmt.Sprintf("Device(%s) has been deleted", uuid))
+			return c.String(http.StatusForbidden, fmt.Sprintf("Device(%s) is on the denied list", uuid))
 		} else if pub != device.PubKey {
 			/*if err := device.RotatePubKey(pub); err != nil {
 				return c.String(http.StatusForbidden, err.Error())

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -39,6 +39,8 @@ func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
 	g.GET("/devices", h.deviceList, requireScope(users.ScopeDevicesR))
 	g.GET("/devices/:uuid", h.deviceGet, requireScope(users.ScopeDevicesR))
 	g.DELETE("/devices/:uuid", h.deviceDelete, requireScope(users.ScopeDevicesD))
+	g.GET("/denied-devices", h.deniedDevicesList, requireScope(users.ScopeDevicesR))
+	g.DELETE("/denied-devices/:uuid", h.undenyDevice, requireScope(users.ScopeDevicesD))
 	g.GET("/devices/:uuid/apps-states", h.deviceAppsStatesGet, requireScope(users.ScopeDevicesR))
 	g.GET("/devices/:uuid/tests", h.deviceTestsList, requireScope(users.ScopeDevicesR))
 	g.GET("/devices/:uuid/tests/:testid", h.deviceTestGet, requireScope(users.ScopeDevicesR))

--- a/server/ui/api/handlers_devices.go
+++ b/server/ui/api/handlers_devices.go
@@ -61,6 +61,23 @@ func (h *handlers) deviceList(c echo.Context) error {
 	return c.JSON(http.StatusOK, devices)
 }
 
+// @Summary List denied devices
+// @Description Returns the UUIDs of all devices on the denied list. Denied devices are prevented from accessing the backend via mTLS. Requires scope: devices:read
+// @Tags    Devices
+// @Produce json
+// @Success 200 {array} string
+// @Router  /denied-devices [get]
+func (h *handlers) deniedDevicesList(c echo.Context) error {
+	uuids, err := h.storage.DeniedDevicesList()
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Unexpected error listing denied devices")
+	}
+	if uuids == nil {
+		uuids = []string{}
+	}
+	return c.JSON(http.StatusOK, uuids)
+}
+
 func setPaginationHeaders(c echo.Context, opts storage.DeviceListOpts, total int) {
 	if opts.Limit <= 0 {
 		return
@@ -121,6 +138,25 @@ func (h *handlers) deviceDelete(c echo.Context) error {
 		}
 		return c.NoContent(http.StatusNoContent)
 	})
+}
+
+// @Summary Remove a device from the denied list
+// @Description Requires scope: devices:delete. Removes the device from the denied list so it can access the backend again. Returns 404 if the device is not on the denied list.
+// @Tags    Devices
+// @Produce json
+// @Success 204
+// @Param   uuid path string true "Device UUID"
+// @Router  /denied-devices/{uuid} [delete]
+func (h *handlers) undenyDevice(c echo.Context) error {
+	uuid := c.Param("uuid")
+	undenied, err := h.storage.UndenyDevice(uuid)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to remove device from denied list")
+	}
+	if !undenied {
+		return c.NoContent(http.StatusNotFound)
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // @Summary Get a list of updates for a device

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -1000,6 +1000,72 @@ func TestApiDeviceDelete(t *testing.T) {
 	tc.GET("/devices/del-device", 404)
 }
 
+func TestApiDeviceUndeny(t *testing.T) {
+	tc := NewTestClient(t)
+
+	// Create and delete a device.
+	_, err := tc.gw.DeviceCreate("restore-device", "pubkey")
+	require.Nil(t, err)
+	tc.u.AllowedScopes = users.ScopeDevicesD
+	tc.DELETE("/devices/restore-device", 204)
+
+	// No permission / wrong scope cannot remove from denied list.
+	tc.u.AllowedScopes = 0
+	tc.DELETE("/denied-devices/restore-device", 403)
+	tc.u.AllowedScopes = users.ScopeDevicesR
+	tc.DELETE("/denied-devices/restore-device", 403)
+
+	// With delete scope: removing an unknown device is a 404.
+	tc.u.AllowedScopes = users.ScopeDevicesD
+	tc.DELETE("/denied-devices/no-such-device", 404)
+
+	// Removing an already-active device is also a 404.
+	_, err = tc.gw.DeviceCreate("active-device", "pubkey2")
+	require.Nil(t, err)
+	tc.DELETE("/denied-devices/active-device", 404)
+
+	// Successful removal from denied list.
+	tc.DELETE("/denied-devices/restore-device", 204)
+
+	// The device is visible again.
+	tc.u.AllowedScopes = users.ScopeDevicesR
+	tc.GET("/devices/restore-device", 200)
+}
+
+func TestApiDeniedDevicesList(t *testing.T) {
+	tc := NewTestClient(t)
+	tc.GET("/denied-devices", 403)
+	tc.u.AllowedScopes = users.ScopeDevicesR
+
+	// No denied devices.
+	data := tc.GET("/denied-devices", 200)
+	var uuids []string
+	require.Nil(t, json.Unmarshal(data, &uuids))
+	require.Len(t, uuids, 0)
+
+	// Create two devices, delete only one of them.
+	_, err := tc.gw.DeviceCreate("live-device", "pubkey1")
+	require.Nil(t, err)
+	_, err = tc.gw.DeviceCreate("gone-device", "pubkey2")
+	require.Nil(t, err)
+	tc.u.AllowedScopes = users.ScopeDevicesD
+	tc.DELETE("/devices/gone-device", 204)
+
+	// Only the denied device shows up in the denied list.
+	tc.u.AllowedScopes = users.ScopeDevicesR
+	data = tc.GET("/denied-devices", 200)
+	require.Nil(t, json.Unmarshal(data, &uuids))
+	require.Len(t, uuids, 1)
+	assert.Equal(t, "gone-device", uuids[0])
+
+	// ...and it is absent from the active list (which has only the live one).
+	var devices []apiStorage.DeviceListItem
+	data = tc.GET("/devices", 200)
+	require.Nil(t, json.Unmarshal(data, &devices))
+	require.Len(t, devices, 1)
+	assert.Equal(t, "live-device", devices[0].Uuid)
+}
+
 func TestApiConfigsFactory(t *testing.T) {
 	tc := NewTestClient(t)
 	const (

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -131,6 +131,10 @@ type Storage struct {
 	stmtUpdateList      stmtUpdateList
 }
 
+// Delete is DESTRUCTIVE. It both adds the device to the denied list in the DB
+// (deleted=1) and removes the device's filesystem data (configs, update
+// events, apps-states). The filesystem data destroyed here is NOT recovered
+// if the device is later allowed back via UndenyDevice.
 func (d Device) Delete() error {
 	err1 := d.storage.stmtDeviceDelete.run(d.Uuid)
 	err2 := d.storage.fs.Devices.Delete(d.Uuid)

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -119,16 +119,18 @@ type Storage struct {
 	db *storage.DbHandle
 	fs *storage.FsHandle
 
-	stmtDeviceCount     stmtDeviceCount
-	stmtDeviceDelete    stmtDeviceDelete
-	stmtDeviceGet       stmtDeviceGet
-	stmtDeviceGetGroups stmtDeviceGetGroups
-	stmtDeviceGetLabels stmtDeviceGetLabels
-	stmtDeviceList      map[OrderBy]stmtDeviceList
-	stmtDeviceSetLabels stmtDeviceSetLabels
-	stmtDeviceSetUpdate stmtDeviceSetUpdate
-	stmtUpdateInsert    stmtUpdateInsert
-	stmtUpdateList      stmtUpdateList
+	stmtDeviceCount      stmtDeviceCount
+	stmtDeviceDelete     stmtDeviceDelete
+	stmtDeviceGet        stmtDeviceGet
+	stmtDeviceGetGroups  stmtDeviceGetGroups
+	stmtDeviceGetLabels  stmtDeviceGetLabels
+	stmtDeviceList       map[OrderBy]stmtDeviceList
+	stmtDeniedDeviceList stmtDeniedDeviceList
+	stmtUndenyDevice     stmtUndenyDevice
+	stmtDeviceSetLabels  stmtDeviceSetLabels
+	stmtDeviceSetUpdate  stmtDeviceSetUpdate
+	stmtUpdateInsert     stmtUpdateInsert
+	stmtUpdateList       stmtUpdateList
 }
 
 // Delete is DESTRUCTIVE. It both adds the device to the denied list in the DB
@@ -204,6 +206,8 @@ func NewStorage(db *storage.DbHandle, fs *storage.FsHandle) (*Storage, error) {
 		&handle.stmtDeviceGet,
 		&handle.stmtDeviceGetGroups,
 		&handle.stmtDeviceGetLabels,
+		&handle.stmtDeniedDeviceList,
+		&handle.stmtUndenyDevice,
 		&handle.stmtDeviceSetLabels,
 		&handle.stmtDeviceSetUpdate,
 		&handle.stmtUpdateInsert,
@@ -245,6 +249,21 @@ func (s Storage) DevicesList(opts DeviceListOpts) ([]DeviceListItem, int, error)
 	}
 
 	return devices, total, nil
+}
+
+// DeniedDevicesList returns the UUIDs of all devices on the denied list
+// (deleted=1). These devices are prevented from accessing the backend via
+// mTLS. The result is capped at 10000 entries to protect against unbounded
+// responses on long-lived fleets.
+func (s Storage) DeniedDevicesList() ([]string, error) {
+	return s.stmtDeniedDeviceList.run()
+}
+
+// UndenyDevice removes a device from the denied list (sets deleted=0 WHERE
+// deleted=1). It returns true when the device was found on the denied list and
+// is now active, false when the device does not exist or was already active.
+func (s Storage) UndenyDevice(uuid string) (bool, error) {
+	return s.stmtUndenyDevice.run(uuid)
 }
 
 func (s Storage) DeviceGet(uuid string) (*Device, error) {
@@ -608,6 +627,58 @@ func (s *stmtDeviceCount) Init(db storage.DbHandle) (err error) {
 func (s *stmtDeviceCount) run() (count int, err error) {
 	err = s.Stmt.QueryRow().Scan(&count)
 	return
+}
+
+type stmtDeniedDeviceList storage.DbStmt
+
+// maxDeniedDevices caps the result set from DeniedDevicesList to protect
+// against unbounded responses on long-lived fleets.
+const maxDeniedDevices = 10000
+
+func (s *stmtDeniedDeviceList) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("apiDeniedDeviceList", fmt.Sprintf(`
+		SELECT uuid FROM devices WHERE deleted=1 LIMIT %d`, maxDeniedDevices),
+	)
+	return
+}
+
+func (s *stmtDeniedDeviceList) run() ([]string, error) {
+	rows, err := s.Stmt.Query()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("failed to close rows in denied device list", "error", err)
+		}
+	}()
+	var uuids []string
+	for rows.Next() {
+		var uuid string
+		if err = rows.Scan(&uuid); err != nil {
+			return nil, err
+		}
+		uuids = append(uuids, uuid)
+	}
+	return uuids, rows.Err()
+}
+
+type stmtUndenyDevice storage.DbStmt
+
+func (s *stmtUndenyDevice) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("apiUndenyDevice", `
+		UPDATE devices SET deleted=0 WHERE uuid=? AND deleted=1`,
+	)
+	return
+}
+
+func (s *stmtUndenyDevice) run(uuid string) (bool, error) {
+	res, err := s.Stmt.Exec(uuid)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
 }
 
 type stmtDeviceSetLabels storage.DbStmt

--- a/storage/api/api_storage_test.go
+++ b/storage/api/api_storage_test.go
@@ -123,6 +123,68 @@ func TestDeviceDelete(t *testing.T) {
 	}
 }
 
+func TestDeviceRestore(t *testing.T) {
+	tmpdir := t.TempDir()
+	dbFile := filepath.Join(tmpdir, "sql.db")
+	db, err := storage.NewDb(dbFile)
+	require.Nil(t, err)
+	fs, err := storage.NewFs(tmpdir)
+	require.Nil(t, err)
+
+	s, err := NewStorage(db, fs)
+	require.Nil(t, err)
+
+	dg, err := gateway.NewStorage(db, fs)
+	require.Nil(t, err)
+
+	// Removing a device that does not exist reports "not found".
+	undenied, err := s.UndenyDevice("no-such-device")
+	require.Nil(t, err)
+	assert.False(t, undenied, "removing an unknown device from denied list should report false")
+
+	// Create and delete a device.
+	_, err = dg.DeviceCreate("uuid-restore", "pubkey-restore")
+	require.Nil(t, err)
+	d, err := s.DeviceGet("uuid-restore")
+	require.Nil(t, err)
+	require.NotNil(t, d)
+	require.Nil(t, d.Delete())
+
+	// The denied device shows up in the denied list, not the active list.
+	uuids, err := s.DeniedDevicesList()
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(uuids), "deleted device should appear in DeniedDevicesList")
+	assert.Equal(t, "uuid-restore", uuids[0])
+
+	devices, count, err := s.DevicesList(DeviceListOpts{Limit: 100})
+	require.Nil(t, err)
+	assert.Equal(t, 0, count, "deleted device should not appear in DevicesList")
+	assert.Equal(t, 0, len(devices))
+
+	// Remove from denied list.
+	undenied, err = s.UndenyDevice("uuid-restore")
+	require.Nil(t, err)
+	assert.True(t, undenied, "removing a denied device should report true")
+
+	// It is back in the active list/get and gone from the denied list.
+	d, err = s.DeviceGet("uuid-restore")
+	require.Nil(t, err)
+	require.NotNil(t, d, "un-denied device should be returned by DeviceGet")
+
+	_, count, err = s.DevicesList(DeviceListOpts{Limit: 100})
+	require.Nil(t, err)
+	assert.Equal(t, 1, count, "un-denied device should appear in DevicesList")
+
+	uuids, err = s.DeniedDevicesList()
+	require.Nil(t, err)
+	assert.Equal(t, 0, len(uuids), "un-denied device should not appear in DeniedDevicesList")
+
+	// Calling UndenyDevice on an already-active device returns false (not on denied list).
+	undenied, err = s.UndenyDevice("uuid-restore")
+	require.Nil(t, err)
+	assert.False(t, undenied, "removing an already-active device from denied list should report false")
+}
+
 func TestUploadConfigs(t *testing.T) {
 	tmpdir := t.TempDir()
 	dbFile := filepath.Join(tmpdir, "sql.db")

--- a/storage/db.go
+++ b/storage/db.go
@@ -79,7 +79,7 @@ func createTables(db *sql.DB) error {
 		CREATE TABLE devices (
 			uuid VARCHAR(48) NOT NULL PRIMARY KEY,
 			pubkey TEXT,
-			deleted BOOL,
+			deleted BOOL DEFAULT 0,
 			created_at INT DEFAULT 0,
 			last_seen INT DEFAULT 0,
 			tag VARCHAR(80) DEFAULT "",


### PR DESCRIPTION
## What

Implements #182 — a way to **list** and **remove** devices from the "deleted" list, across the storage, REST, and CLI layers, plus docs.

Deleting a device (`DELETE /devices/{uuid}`) soft-deletes it (`deleted=1`) and stops it being served. Until now there was no way to see which devices are in that state or to bring one back. This adds:

- **REST**
  - `GET /v1/devices/deleted` — list soft-deleted devices; paginated/sortable exactly like `GET /devices`. Scope: `devices:read`.
  - `POST /v1/devices/{uuid}/restore` — remove a device from the deleted list (clears the tombstone). Idempotent. Scope: `devices:delete`.
- **CLI**
  - `fiocli devices list-deleted` — mirrors `devices list` (same columns/sort/paging).
  - `fiocli devices restore <uuid>`.
- **Docs** — `docs/api.md` updated (Swagger is generated from the handler annotations at release time).

## Design notes

- **Separate `GET /devices/deleted` collection rather than a `?deleted=true` param.** Every device statement (`stmtDeviceGet`/`List`/`Count`) hard-filters `WHERE deleted=false`, and the list statements are pre-built per sort order in a `map[OrderBy]stmtDeviceList`. A query param would force those clean statements to become conditional/dynamic; a parallel statement set is purely additive. Echo's router matches the static `deleted` segment before `:uuid`, so there's no route shadowing.
- **`POST .../restore`, idempotent.** `UPDATE devices SET deleted=0 WHERE uuid=?` with no `AND deleted=1` guard. `RowsAffected > 0` → `204` (uuid exists, whether it was deleted or already active); `0` → `404` (unknown uuid). A retry after a dropped `204` returns `204`, not a spurious `404`. (Relies on SQLite's matched-rows semantics for `RowsAffected` — noted at the call site.)
- **Scopes:** list = `devices:read` (like `GET /devices`); restore = `devices:delete` (the inverse of delete). No new scope introduced.

## ⚠️ Restore is DB-record-only

`Device.Delete()` sets `deleted=1` **and** destroys the device's filesystem data (`os.RemoveAll` of configs, update events, apps-states). Restore therefore recovers the **server record only** — that history is not recovered. This is documented in a `Device.Delete()` doc comment and in `docs/api.md`; `Delete()` behaviour is intentionally **not** changed here.

**Order-of-operations gotcha (documented):** the restored record keeps the device's pre-deletion public key, and the gateway does not support key rotation. A device that regenerated its key *while deleted* (e.g. after a factory reset) cannot be restored — once restored it presents a new key that no longer matches the stored one, and because a record still exists the gateway won't auto-enrol it either. Such a device must be deleted and re-enrolled from scratch.

## Boy-scout fixes

- Added `DEFAULT 0` to the `devices.deleted` column (it had no default, unlike `users.deleted`).
- Documented `Device.Delete()` as destructive.

## Suggested follow-up

Make `Device.Delete()` non-destructive — retain filesystem data behind the `deleted=1` tombstone instead of `os.RemoveAll` — so restore becomes lossless. Supporting gateway key rotation (the commented-out `RotatePubKey` path) would additionally make restore robust to key changes.

## Commits

Six small, independently-reviewable commits (each builds + tests green, for clean `git bisect`):

1. `fix:` add `DEFAULT 0` to `devices.deleted` column
2. `refactor:` document `Device.Delete()` as destructive
3. `feat:` storage support for listing and restoring deleted devices
4. `feat:` REST endpoints to list and restore deleted devices
5. `feat:` CLI commands to list and restore deleted devices
6. `docs:` document deleted-device list and restore endpoints

## Testing

- `go build ./...` and `make fioserver` — clean.
- `go test ./...` — all packages pass, including new `TestDeviceRestore`, `TestApiDeviceRestore`, and `TestApiDeviceListDeleted`.
- Swagger annotations validated with `make swagger`; both new paths appear in the generated spec.

Closes #182
