### PR TITLE
Add support for oauth2 device flow

### DIFF
--- a/auth/csrf.go
+++ b/auth/csrf.go
@@ -46,6 +46,10 @@ func CsrfCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			return next(c)
 		}
 
+		if c.Path() == "/oauth2/authorization/device/" || c.Path() == "/oauth2/token/" {
+			return next(c)
+		}
+
 		cookie, err := c.Cookie(CsrfCookieName)
 		if err != nil || cookie.Value == "" {
 			return c.String(http.StatusForbidden, "Missing CSRF cookie")

--- a/auth/noauth.go
+++ b/auth/noauth.go
@@ -69,6 +69,14 @@ func (p noauthProvider) GetSession(c echo.Context) (*Session, error) {
 func (noauthProvider) DropSession(echo.Context, *Session) {
 }
 
+func (noauthProvider) GetRateLimiterMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			return next(c)
+		}
+	}
+}
+
 func init() {
 	RegisterProvider(&noauthProvider{})
 }

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -46,6 +46,8 @@ type Provider interface {
 	// GetSession retrieves the session associated with the given context.
 	GetSession(c echo.Context) (*Session, error)
 	DropSession(c echo.Context, session *Session)
+
+	GetRateLimiterMiddleware() echo.MiddlewareFunc
 }
 
 const AuthCookieName = "fioserver-session"

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -52,7 +53,17 @@ func (p *commonProvider) GetUser(c echo.Context) (*users.User, error) {
 				return nil, fmt.Errorf("invalid authorization header")
 			}
 			authToken = parts[1]
+
+			if c.Request().Method == http.MethodPost && c.Request().URL.Path == "/v1/devices" {
+				// lmp-device-register with oauth2-device-flow sends the token b64encoded
+				decoded, err := base64.StdEncoding.DecodeString(authToken)
+				if err != nil {
+					return nil, fmt.Errorf("invalid base64 token: %w", err)
+				}
+				authToken = string(decoded)
+			}
 		}
+
 		user, err := p.users.GetByToken(authToken)
 		if err != nil {
 			p.rateLimiter.FlagBadOperation(c)

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -94,3 +94,7 @@ func (p *commonProvider) GetSession(c echo.Context) (*Session, error) {
 	}
 	return nil, p.renderer.renderLoginPage(c, "")
 }
+
+func (p *commonProvider) GetRateLimiterMiddleware() echo.MiddlewareFunc {
+	return p.rateLimiter.Middleware
+}

--- a/cli/subcommands/login/cmd.go
+++ b/cli/subcommands/login/cmd.go
@@ -4,12 +4,18 @@
 package login
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/foundriesio/update-server/cli/config"
+	models "github.com/foundriesio/update-server/server/ui/api"
 )
 
 var LoginCmd = &cobra.Command{
@@ -27,23 +33,32 @@ the configuration to ~/.config/satcli.yaml.`,
 		token, _ := cmd.Flags().GetString("token")
 		setDefault, _ := cmd.Flags().GetBool("set-default")
 		configPath, _ := cmd.Flags().GetString("config")
+		scopes, _ := cmd.Flags().GetString("scopes")
+		expiresInDays, _ := cmd.Flags().GetInt("expires-in-days")
 
-		cobra.CheckErr(login(contextName, serverURL, token, configPath, setDefault))
+		cobra.CheckErr(login(configPath, contextName, serverURL, token, scopes, expiresInDays, setDefault))
 	},
 }
 
 func init() {
-	LoginCmd.Flags().String("token", "", "API token for authentication (required for now)")
+	LoginCmd.Flags().String("token", "", "API token for authentication (skips OAuth2 device flow)")
 	LoginCmd.Flags().Bool("set-default", true, "Set this context as the default")
 	LoginCmd.Flags().String("config", "", "Specify the configuration file to use")
-	cobra.CheckErr(LoginCmd.MarkFlagRequired("token"))
+	LoginCmd.Flags().String("scopes", "devices:read-update,updates:read-update", "Comma-separated list of OAuth2 scopes to request (optional)")
+	LoginCmd.Flags().Int("expires-in-days", 90, "Number of days until the access token expires")
 }
 
-func login(contextName, serverURL, token, configPath string, setDefault bool) error {
-	if token == "" {
-		return fmt.Errorf("--token is required")
+func login(configPath, contextName, serverURL, token, scopes string, expiresInDays int, setDefault bool) error {
+	if token != "" {
+		return saveToken(configPath, contextName, serverURL, token, setDefault)
 	}
 
+	fmt.Println("Initiating OAuth2 device authorization flow...")
+	expires := time.Now().Add(time.Duration(expiresInDays) * 24 * time.Hour).Unix()
+	return oauth2DeviceFlow(configPath, contextName, serverURL, scopes, expires, setDefault)
+}
+
+func saveToken(configPath, contextName, serverURL, token string, setDefault bool) error {
 	// Load existing config or create new one
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
@@ -79,4 +94,122 @@ func login(contextName, serverURL, token, configPath string, setDefault bool) er
 	}
 
 	return nil
+}
+
+type oauth2Error struct {
+	ErrorCode        string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func (e *oauth2Error) Error() string {
+	if e.ErrorDescription != "" {
+		return fmt.Sprintf("%s: %s", e.ErrorCode, e.ErrorDescription)
+	}
+	return e.ErrorCode
+}
+
+func oauth2DeviceFlow(configPath, contextName, serverURL, scopes string, expires int64, setDefault bool) error {
+	// Request device code
+	formData := url.Values{}
+	formData.Set("scope", scopes)
+	formData.Set("token_expires", fmt.Sprintf("%d", expires))
+
+	resp, err := http.PostForm(serverURL+"/oauth2/authorization/device/", formData)
+	if err != nil {
+		return fmt.Errorf("failed to request device code: %w", err)
+	}
+	defer resp.Body.Close() // nolint:errcheck
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to get device code (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var codeResp models.DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&codeResp); err != nil {
+		return fmt.Errorf("failed to decode device code response: %w", err)
+	}
+
+	// Display user code and verification URI
+	fmt.Println()
+	fmt.Println("------------------------------------------------")
+	fmt.Printf("  Visit: %s\n", codeResp.VerificationURI)
+	fmt.Println()
+	fmt.Printf("  Enter code: %s\n", codeResp.UserCode)
+	fmt.Println("------------------------------------------------")
+	fmt.Println()
+	fmt.Println("Waiting for authorization...")
+
+	// Poll for token
+	pollInterval := time.Duration(codeResp.Interval) * time.Second
+	expiresAt := time.Now().Add(time.Duration(codeResp.ExpiresIn) * time.Second)
+
+	for time.Now().Before(expiresAt) {
+		time.Sleep(pollInterval)
+
+		token, err := pollForToken(serverURL, codeResp.DeviceCode)
+		if err == nil {
+			// Success! Save the token
+			fmt.Println()
+			fmt.Println("✓ Authorization successful!")
+			return saveToken(configPath, contextName, serverURL, token, setDefault)
+		}
+
+		// Check if we should continue polling
+		if oauth2Err, ok := err.(*oauth2Error); ok {
+			switch oauth2Err.ErrorCode {
+			case "authorization_pending":
+				continue
+			case "slow_down":
+				pollInterval *= 2
+				continue
+			case "access_denied":
+				return fmt.Errorf("authorization was denied")
+			case "expired_token":
+				return fmt.Errorf("authorization code expired")
+			default:
+				return fmt.Errorf("OAuth2 error: %s - %s", oauth2Err.ErrorCode, oauth2Err.ErrorDescription)
+			}
+		}
+
+		return fmt.Errorf("failed to get token: %w", err)
+	}
+
+	return fmt.Errorf("authorization timed out")
+}
+
+func pollForToken(serverURL, deviceCode string) (string, error) {
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	formData.Set("device_code", deviceCode)
+
+	resp, err := http.PostForm(serverURL+"/oauth2/token/", formData)
+	if err != nil {
+		return "", fmt.Errorf("failed to request token: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == 200 {
+		var tokenResp models.DeviceTokenResponse
+		if err := json.Unmarshal(body, &tokenResp); err != nil {
+			return "", fmt.Errorf("failed to decode token response: %w", err)
+		}
+		return tokenResp.AccessToken, nil
+	}
+
+	var errResp oauth2Error
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		return "", fmt.Errorf("request failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return "", &errResp
 }

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -17,15 +17,22 @@ import (
 type handlers struct {
 	ca      *DeviceCa
 	storage *storage.Storage
+	users   *users.Storage
 }
 
 var EchoError = server.EchoError
 
-func RegisterHandlers(e *echo.Echo, ca *DeviceCa, storage *storage.Storage, a auth.Provider) {
+func RegisterHandlers(e *echo.Echo, ca *DeviceCa, storage *storage.Storage, userStorage *users.Storage, a auth.Provider) {
 	h := handlers{
 		ca:      ca,
 		storage: storage,
+		users:   userStorage,
 	}
+
+	// OAuth2 endpoints (no authentication required)
+	oauth2 := oauth2Handlers{users: userStorage}
+	e.POST("/oauth2/authorization/device/", oauth2.oauth2DeviceCode, a.GetRateLimiterMiddleware())
+	e.POST("/oauth2/token/", oauth2.oauth2DeviceToken, a.GetRateLimiterMiddleware())
 
 	g := e.Group("/v1")
 	g.Use(authUser(a))

--- a/server/ui/api/handlers_oauth2.go
+++ b/server/ui/api/handlers_oauth2.go
@@ -1,0 +1,210 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/foundriesio/update-server/storage/users"
+)
+
+type oauth2Handlers struct {
+	users *users.Storage
+}
+
+type DeviceCodeRequest struct {
+	Scopes       string `form:"scope"`
+	TokenExpires int64  `form:"token_expires"`
+}
+
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"` // seconds until expiry, per RFC 8628
+	Interval                int    `json:"interval"`
+}
+
+type DeviceTokenRequest struct {
+	DeviceCode string `form:"device_code"`
+	GrantType  string `form:"grant_type"`
+}
+
+type DeviceTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Expires     int64  `json:"expires"`
+	Scopes      string `json:"scope"`
+}
+
+type oauth2Error struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// @Summary Initiate OAuth2 Device Authorization
+// @Accept json
+// @Param data body DeviceCodeRequest true "Device code request"
+// @Produce json
+// @Success 200
+// @Router  /oauth2/device/code [post]
+func (h oauth2Handlers) oauth2DeviceCode(c echo.Context) error {
+	var req DeviceCodeRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_request",
+			ErrorDescription: "Invalid request body",
+		})
+	}
+
+	scopes := strings.Split(req.Scopes, ",")
+	if len(scopes) == 1 {
+		// might be lmp-dr
+		parts := strings.Split(scopes[0], ":")
+		if len(parts) == 3 {
+			// looks like lmp-dr, convert to proper scope string
+			req.Scopes = parts[1] + ":" + parts[2]
+		}
+		CtxGetLog(c.Request().Context()).Info("Assuming lmp-device-register format for scopes", "scopes", req.Scopes)
+
+		if req.TokenExpires == 0 {
+			// lmp-dr doesn't send token_expires, set to 5 minutes
+			req.TokenExpires = time.Now().Add(5 * time.Minute).Unix()
+		}
+	}
+
+	const deviceCodeTTL = 10 * time.Minute
+	expires := time.Now().Add(deviceCodeTTL).Unix()
+	deviceCode, userCode, err := h.users.CreateDeviceAuth(expires, req.TokenExpires, req.Scopes)
+	if err != nil {
+		return EchoError(c, err, http.StatusBadRequest, err.Error())
+	}
+
+	baseURL := c.Scheme() + "://" + c.Request().Host
+	verificationURI := baseURL + "/auth/activate"
+	verificationURIComplete := fmt.Sprintf("%s?user_code=%s", verificationURI, userCode)
+
+	return c.JSON(http.StatusOK, DeviceCodeResponse{
+		DeviceCode:              deviceCode,
+		UserCode:                userCode,
+		VerificationURI:         verificationURI,
+		VerificationURIComplete: verificationURIComplete,
+		ExpiresIn:               int(deviceCodeTTL.Seconds()),
+		Interval:                5, // Poll every 5 seconds
+	})
+}
+
+// @Summary Handle OAuth2 Device Token Polling
+// @Accept json
+// @Param data body DeviceTokenRequest true "Device token request"
+// @Produce json
+// @Success 200
+// @Router  /oauth2/device/token [post]
+func (h oauth2Handlers) oauth2DeviceToken(c echo.Context) error {
+	var req DeviceTokenRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_request",
+			ErrorDescription: "Invalid request body",
+		})
+	}
+
+	if req.GrantType != "urn:ietf:params:oauth:grant-type:device_code" {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "unsupported_grant_type",
+			ErrorDescription: "Only device_code grant type is supported",
+		})
+	}
+
+	if req.DeviceCode == "" {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_request",
+			ErrorDescription: "device_code is required",
+		})
+	}
+
+	auth, err := h.users.GetDeviceAuthByDeviceCode(req.DeviceCode)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get authorization")
+	}
+	if auth == nil {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_grant",
+			ErrorDescription: "Invalid device code",
+		})
+	}
+
+	if auth.ExpiresAt < time.Now().Unix() {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_grant",
+			ErrorDescription: "Invalid device code",
+		})
+	}
+
+	if auth.Denied {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "access_denied",
+			ErrorDescription: "User denied the authorization request",
+		})
+	}
+
+	if !auth.Authorized {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "authorization_pending",
+			ErrorDescription: "User has not yet authorized this device",
+		})
+	}
+
+	if auth.UserID == nil {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_grant",
+			ErrorDescription: "No user associated with this authorization",
+		})
+	}
+
+	user, err := h.users.GetByID(*auth.UserID)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get user for authorization")
+	}
+	if user == nil {
+		return c.JSON(http.StatusBadRequest, oauth2Error{
+			Error:            "invalid_grant",
+			ErrorDescription: "User for authorization not found",
+		})
+	}
+
+	scopes, err := users.ScopesFromString(auth.Scopes)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to parse scopes")
+	}
+
+	if len(auth.TokenDescription) == 0 {
+		auth.TokenDescription = "OAuth2 authorization"
+	}
+	scopes = user.AllowedScopes & scopes
+
+	// Delete before generating: if generation fails the user must re-authorize,
+	// but we avoid issuing a second token if deletion fails after a successful insert.
+	if err := h.users.DeleteDeviceAuth(auth.DeviceCode); err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to consume device authorization")
+	}
+
+	token, err := user.GenerateToken(auth.TokenDescription, auth.TokenExpires, scopes)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to generate token")
+	}
+
+	return c.JSON(http.StatusOK, DeviceTokenResponse{
+		AccessToken: token.Value,
+		TokenType:   "Bearer",
+		Expires:     auth.TokenExpires,
+		Scopes:      scopes.String(),
+	})
+}

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -278,11 +278,14 @@ func NewTestClientWithCA(t *testing.T, org string) *testClient {
 	tmpDir := t.TempDir()
 	fsS, err := apiStorage.NewFs(tmpDir)
 	require.Nil(t, err)
+	require.Nil(t, fsS.Auth.InitHmacSecret())
 	db, err := apiStorage.NewDb(filepath.Join(tmpDir, apiStorage.DbFile))
 	require.Nil(t, err)
 	apiS, err := apiStorage.NewStorage(db, fsS)
 	require.Nil(t, err)
 	gwS, err := gatewayStorage.NewStorage(db, fsS)
+	require.Nil(t, err)
+	userS, err := users.NewStorage(db, fsS, &storage.AuthConfig{})
 	require.Nil(t, err)
 
 	var deviceCa *DeviceCa
@@ -350,7 +353,7 @@ func NewTestClientWithCA(t *testing.T, org string) *testClient {
 		Username:      "root",
 		AllowedScopes: 0,
 	}
-	RegisterHandlers(e, deviceCa, apiS, &testAuthProvider{user: u})
+	RegisterHandlers(e, deviceCa, apiS, userS, &testAuthProvider{user: u})
 
 	tc := testClient{
 		t:   t,
@@ -961,7 +964,6 @@ func TestApiRolloutPut(t *testing.T) {
 func TestApiRolloutDaemon(t *testing.T) {
 	tc := NewTestClient(t)
 
-	require.Nil(t, tc.fs.Auth.InitHmacSecret())
 	db, err := apiStorage.NewDb(filepath.Join(t.TempDir(), apiStorage.DbFile))
 	require.Nil(t, err)
 	usersS, err := users.NewStorage(db, tc.fs, nil)

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -263,6 +263,12 @@ func (p testAuthProvider) GetSession(c echo.Context) (*auth.Session, error) {
 func (testAuthProvider) DropSession(echo.Context, *auth.Session) {
 }
 
+func (testAuthProvider) GetRateLimiterMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return next
+	}
+}
+
 func NewTestClient(t *testing.T) *testClient {
 	return NewTestClientWithCA(t, "")
 }

--- a/server/ui/api/handlers_tuf_test.go
+++ b/server/ui/api/handlers_tuf_test.go
@@ -24,7 +24,6 @@ func TestApiTufRoot(t *testing.T) {
 	// Before TUF is initialized there is no root metadata.
 	tc.GET("/tuf/root.json", 404)
 
-	require.Nil(t, tc.fs.Auth.InitHmacSecret())
 	require.Nil(t, tc.fs.Tuf.InitTuf())
 
 	// The latest root.json is returned and is valid v1 root metadata.

--- a/server/ui/server.go
+++ b/server/ui/server.go
@@ -67,7 +67,7 @@ func NewServer(ctx context.Context, db *storage.DbHandle, fs *storage.FsHandle, 
 
 	srv := server.NewServer(ctx, e, serverName, bindAddr, nil)
 	e.Use(auth.CsrfCheck)
-	apiHandlers.RegisterHandlers(e, ca, strg, provider)
+	apiHandlers.RegisterHandlers(e, ca, strg, users, provider)
 	webHandlers.RegisterHandlers(e, users, provider, branding, fs.Config.BrandingDir(), pageBuilder)
 	return &apiServer{server: srv, daemons: daemons}, nil
 }

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -53,9 +53,17 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.Renderer = h
 
 	e.GET("/", h.index, h.requireSession)
+
+	rateLimiter := authProvider.GetRateLimiterMiddleware()
+	e.GET("/auth/activate", h.authDevice, h.requireSession)
+	e.GET("/auth/confirm-activation", h.authDeviceConfirm, h.requireSession, rateLimiter)
+	e.POST("/auth/authorize-activation", h.authDeviceAuthorize, h.requireSession, rateLimiter)
+	e.POST("/auth/deny-activation", h.authDeviceDeny, h.requireSession, rateLimiter)
+
 	e.GET("/css/:filename", h.css)
 	e.GET("/branding/:filename", h.brandingAsset)
 	e.GET("/favicon", h.favicon)
+
 	e.GET("/auth/logout", h.authLogout, h.requireSession)
 	e.GET("/configs", h.configsList, h.requireSession, h.requireScope(users.ScopeDevicesR))
 	e.GET("/configs/device/:uuid", h.configsDeviceItem, h.requireSession, h.requireScope(users.ScopeDevicesR))

--- a/server/ui/web/handlers_oauth2.go
+++ b/server/ui/web/handlers_oauth2.go
@@ -1,0 +1,168 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package web
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/foundriesio/update-server/storage/users"
+)
+
+func (h handlers) authDevice(c echo.Context) error {
+	userCode := c.QueryParam("user_code")
+
+	data := struct {
+		baseCtx
+		UserCode string
+	}{
+		baseCtx:  h.baseCtx(c, "API Activation", "settings"),
+		UserCode: userCode,
+	}
+
+	return c.Render(http.StatusOK, "device_auth.html", data)
+}
+
+var errDeviceAuthInvalidCode = errors.New("invalid user code")
+var errDeviceAuthExpired = errors.New("authorization code expired")
+var errDeviceAuthAlreadyHandled = errors.New("this device has already been authorized or denied")
+
+func (h handlers) authDeviceConfirm(c echo.Context) error {
+	userCode := c.QueryParam("user_code")
+	if userCode == "" {
+		return EchoError(c, nil, http.StatusBadRequest, "user_code is required")
+	}
+
+	auth, err := h.users.GetDeviceAuthByUserCode(userCode)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get device authorization")
+	}
+	if auth == nil {
+		return EchoError(c, errDeviceAuthInvalidCode, http.StatusNotFound, errDeviceAuthInvalidCode.Error())
+	}
+
+	if auth.ExpiresAt < time.Now().Unix() {
+		return EchoError(c, errDeviceAuthExpired, http.StatusBadRequest, errDeviceAuthExpired.Error())
+	}
+	if auth.Authorized || auth.Denied {
+		return EchoError(c, errDeviceAuthAlreadyHandled, http.StatusBadRequest, errDeviceAuthAlreadyHandled.Error())
+	}
+
+	// Get the current user from session to intersect scopes
+	session := CtxGetSession(c.Request().Context())
+	if session == nil || session.User == nil {
+		return EchoError(c, nil, http.StatusUnauthorized, "Not authenticated")
+	}
+
+	scopes, err := users.ScopesFromString(auth.Scopes)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to parse requested scopes: "+auth.Scopes)
+	}
+	allowedScopes := scopes & session.User.AllowedScopes
+	if allowedScopes == 0 {
+		return EchoError(c, nil, http.StatusForbidden, fmt.Sprintf("user is missing required scope(s): %s", scopes))
+	}
+
+	data := struct {
+		baseCtx
+		UserCode     string
+		Scopes       string
+		TokenExpires int64
+	}{
+		baseCtx:      h.baseCtx(c, "API Activation", "settings"),
+		UserCode:     userCode,
+		Scopes:       allowedScopes.String(),
+		TokenExpires: auth.TokenExpires,
+	}
+
+	return c.Render(http.StatusOK, "device_auth_confirm.html", data)
+}
+
+func (h handlers) authDeviceAuthorize(c echo.Context) error {
+	userCode := c.FormValue("user_code")
+	if userCode == "" {
+		return EchoError(c, nil, http.StatusBadRequest, "user_code is required")
+	}
+	description := c.FormValue("token_description")
+
+	auth, err := h.users.GetDeviceAuthByUserCode(userCode)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get device authorization")
+	}
+	if auth == nil {
+		return EchoError(c, errDeviceAuthInvalidCode, http.StatusNotFound, errDeviceAuthInvalidCode.Error())
+	}
+
+	if auth.ExpiresAt < time.Now().Unix() {
+		return EchoError(c, errDeviceAuthExpired, http.StatusBadRequest, errDeviceAuthExpired.Error())
+	}
+
+	if auth.Authorized || auth.Denied {
+		return EchoError(c, errDeviceAuthAlreadyHandled, http.StatusBadRequest, errDeviceAuthAlreadyHandled.Error())
+	}
+
+	session := CtxGetSession(c.Request().Context())
+
+	scopes, err := users.ScopesFromString(auth.Scopes)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to parse requested scopes: "+auth.Scopes)
+	}
+	allowedScopes := scopes & session.User.AllowedScopes
+
+	if err := session.User.ApproveAuthorization(auth.DeviceCode, description, allowedScopes); err != nil {
+		return h.handleUnexpected(c, err)
+	}
+
+	data := struct {
+		baseCtx
+		Message string
+	}{
+		baseCtx: h.baseCtx(c, "API Activation", "settings"),
+		Message: "Activation successful! You can close this window and return to your device.",
+	}
+	return c.Render(http.StatusOK, "device_auth_success.html", data)
+}
+
+// authDeviceDeny handles the user denying the device authorization
+// POST /auth/device/deny
+func (h handlers) authDeviceDeny(c echo.Context) error {
+	userCode := c.FormValue("user_code")
+	if userCode == "" {
+		return EchoError(c, nil, http.StatusBadRequest, "user_code is required")
+	}
+
+	auth, err := h.users.GetDeviceAuthByUserCode(userCode)
+	if err != nil {
+		return h.handleError(c, http.StatusInternalServerError, errors.New("failed to get device authorization"))
+	}
+	if auth == nil {
+		return h.handleError(c, http.StatusNotFound, errDeviceAuthInvalidCode)
+	}
+
+	if auth.ExpiresAt < time.Now().Unix() {
+		return h.handleError(c, http.StatusBadRequest, errDeviceAuthExpired)
+	}
+
+	if auth.Authorized || auth.Denied {
+		return h.handleError(c, http.StatusBadRequest, errDeviceAuthAlreadyHandled)
+	}
+
+	session := CtxGetSession(c.Request().Context())
+	if err := session.User.DenyDeviceAuth(auth.DeviceCode); err != nil {
+		return h.handleUnexpected(c, err)
+	}
+
+	data := struct {
+		baseCtx
+		Message string
+	}{
+		baseCtx: h.baseCtx(c, "API Activation", "settings"),
+		Message: "Activation denied. You can close this window.",
+	}
+	return c.Render(http.StatusOK, "device_auth_success.html", data)
+}

--- a/server/ui/web/templates/device_auth.html
+++ b/server/ui/web/templates/device_auth.html
@@ -1,0 +1,16 @@
+{{ template "header" .}}
+    <section class="content-section">
+      <h2>Activate</h2>
+      <p>A user or device is requesting access to your account. Please enter the code shown on your device.</p>
+      
+      <form method="GET" action="/auth/confirm-activation">
+        <label for="user_code">
+          User Code
+          <input type="text" id="user_code" name="user_code" value="{{.UserCode}}" placeholder="XXXX-XXXX" required autofocus>
+        </label>
+        
+        <button type="submit">Next</button>
+      </form>
+    </section>
+
+{{ template "footer"}}

--- a/server/ui/web/templates/device_auth_confirm.html
+++ b/server/ui/web/templates/device_auth_confirm.html
@@ -1,0 +1,36 @@
+{{ template "header" .}}
+    <section class="content-section">
+      <h2>Activate</h2>
+      <p>A user or device is requesting access to your account with the following details:</p>
+      
+      <article>
+        <header><strong>Request</strong></header>
+        <table>
+          <tr>
+            <td><strong>User code:</strong></td>
+            <td>{{.UserCode}}</td>
+          </tr>
+          <tr>
+            <td><strong>Requested scopes:</strong></td>
+            <td>{{if .Scopes}}{{.Scopes}}{{else}}<em>All available scopes</em>{{end}}</td>
+          </tr>
+          <tr>
+            <td><strong>Access token would expire:</strong></td>
+            <td>{{tsToString .TokenExpires}}</td>
+          </tr>
+        </table>
+      </article>
+
+      <p>Do you want to authorize this access to your account?</p>
+
+      <form method="POST" action="/auth/authorize-activation" style="display: inline;">
+        <input type="hidden" name="_csrf" value="{{.CsrfToken}}">
+        <input type="hidden" name="user_code" value="{{.UserCode}}">
+        <label for="token_description">Token description (optional):</label>
+        <input type="text" name="token_description" placeholder="OAuth2 authorization"/>
+        <button type="submit" formaction="/auth/deny-activation" class="secondary">Deny</button>
+        <button type="submit">Authorize</button>
+      </form>
+    </section>
+
+{{ template "footer"}}

--- a/server/ui/web/templates/device_auth_success.html
+++ b/server/ui/web/templates/device_auth_success.html
@@ -1,0 +1,7 @@
+{{ template "header" .}}
+    <section class="content-section">
+      <h2>Activation Complete</h2>
+      <p>{{.Message}}</p>
+    </section>
+
+{{ template "footer"}}

--- a/storage/db.go
+++ b/storage/db.go
@@ -180,6 +180,19 @@ func createTables(db *sql.DB) error {
 			BEGIN
 				SELECT RAISE(ABORT, '%s');
 			END;
+
+		CREATE TABLE oauth2_device_flow(
+			device_code        VARCHAR(64) NOT NULL PRIMARY KEY,
+			user_code          VARCHAR(16) NOT NULL UNIQUE,
+			expires_at         INT,
+			token_expires      INT,
+			token_description  VARCHAR(80),
+			scopes             TEXT,
+			user_id            INT,
+			authorized         BOOL DEFAULT 0,
+			denied             BOOL DEFAULT 0,
+			FOREIGN KEY(user_id) REFERENCES user(id)
+		) WITHOUT ROWID;
 	`
 	sqlStmt = fmt.Sprintf(sqlStmt, ErrUpdateInUse.Error())
 	if _, err := db.Exec(sqlStmt); err != nil {

--- a/storage/users/oauth2.go
+++ b/storage/users/oauth2.go
@@ -1,0 +1,231 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package users
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/foundriesio/update-server/storage"
+)
+
+// OAuth2DeviceAuth represents an OAuth2 device-flow authorization request
+type OAuth2DeviceAuth struct {
+	DeviceCode       string
+	UserCode         string
+	ExpiresAt        int64
+	TokenExpires     int64  // What time the issued token should expire
+	TokenDescription string // Description to be stored with the issued token
+	Scopes           string // The scopes to be assigned to the token
+	UserID           *int64
+	Authorized       bool
+	Denied           bool
+}
+
+func (s Storage) CreateDeviceAuth(expiresAt, tokenExpires int64, scopes string) (string, string, error) {
+	if _, err := ScopesFromString(scopes); err != nil {
+		return "", "", err
+	}
+	if s.authConfig.MaxTokenLifetimeDays > 0 {
+		maxExpires := time.Now().Add(time.Duration(s.authConfig.MaxTokenLifetimeDays) * 24 * time.Hour).Unix()
+		if expiresAt > maxExpires {
+			return "", "", fmt.Errorf("requested expiration exceeds maximum allowed expiration %d days", s.authConfig.MaxTokenLifetimeDays)
+		}
+	}
+	deviceCode := rand.Text()
+	userCode := rand.Text()
+	userCode = userCode[:4] + "-" + userCode[4:8]
+	return deviceCode, userCode, s.stmtOAuth2DeviceAuthCreate.run(deviceCode, userCode, expiresAt, tokenExpires, scopes)
+}
+
+func (s Storage) GetDeviceAuthByDeviceCode(deviceCode string) (*OAuth2DeviceAuth, error) {
+	return s.stmtOAuth2DeviceAuthGetByDeviceCode.run(deviceCode)
+}
+
+func (s Storage) GetDeviceAuthByUserCode(userCode string) (*OAuth2DeviceAuth, error) {
+	return s.stmtOAuth2DeviceAuthGetByUserCode.run(userCode)
+}
+
+func (s Storage) DeleteExpiredDeviceAuth(before int64) error {
+	return s.stmtOAuth2DeviceAuthDeleteExpired.run(before)
+}
+
+func (s Storage) DeleteDeviceAuth(deviceCode string) error {
+	return s.stmtOAuth2DeviceAuthDelete.run(deviceCode)
+}
+
+func (u User) ApproveAuthorization(deviceCode string, tokenDescription string, scopes Scopes) error {
+	if err := u.h.stmtOAuth2DeviceAuthAuthorize.run(u.id, deviceCode, tokenDescription, scopes.String()); err != nil {
+		return err
+	}
+	u.h.fs.Audit.AppendEvent(u.id, "OAuth2 device authorized: "+tokenDescription)
+	return nil
+}
+
+func (u User) DenyDeviceAuth(deviceCode string) error {
+	if err := u.h.stmtOAuth2DeviceAuthDeny.run(deviceCode); err != nil {
+		return err
+	}
+	u.h.fs.Audit.AppendEvent(u.id, "OAuth2 device denied")
+	return nil
+}
+
+type stmtOAuth2DeviceAuthCreate storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthCreate) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthCreate", `
+		INSERT INTO oauth2_device_flow (device_code, user_code, expires_at, token_expires, token_description, scopes)
+		VALUES (?, ?, ?, ?, "", ?)`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthCreate) run(deviceCode, userCode string, expiresAt, tokenExpires int64, scopes string) error {
+	_, err := s.Stmt.Exec(deviceCode, userCode, expiresAt, tokenExpires, scopes)
+	return err
+}
+
+type stmtOAuth2DeviceAuthGetByDeviceCode storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthGetByDeviceCode) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthGetByDeviceCode", `
+		SELECT device_code, user_code, expires_at, token_expires, token_description, scopes, user_id, authorized, denied
+		FROM oauth2_device_flow
+		WHERE device_code = ?`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthGetByDeviceCode) run(deviceCode string) (*OAuth2DeviceAuth, error) {
+	auth := &OAuth2DeviceAuth{}
+	var userID sql.NullInt64
+
+	err := s.Stmt.QueryRow(deviceCode).Scan(
+		&auth.DeviceCode,
+		&auth.UserCode,
+		&auth.ExpiresAt,
+		&auth.TokenExpires,
+		&auth.TokenDescription,
+		&auth.Scopes,
+		&userID,
+		&auth.Authorized,
+		&auth.Denied,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if userID.Valid {
+		auth.UserID = &userID.Int64
+	}
+
+	return auth, nil
+}
+
+type stmtOAuth2DeviceAuthGetByUserCode storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthGetByUserCode) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthGetByUserCode", `
+		SELECT device_code, user_code, expires_at, token_expires, token_description, scopes, user_id, authorized, denied
+		FROM oauth2_device_flow
+		WHERE user_code = ?`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthGetByUserCode) run(userCode string) (*OAuth2DeviceAuth, error) {
+	auth := &OAuth2DeviceAuth{}
+	var userID sql.NullInt64
+
+	err := s.Stmt.QueryRow(userCode).Scan(
+		&auth.DeviceCode,
+		&auth.UserCode,
+		&auth.ExpiresAt,
+		&auth.TokenExpires,
+		&auth.TokenDescription,
+		&auth.Scopes,
+		&userID,
+		&auth.Authorized,
+		&auth.Denied,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if userID.Valid {
+		auth.UserID = &userID.Int64
+	}
+
+	return auth, nil
+}
+
+type stmtOAuth2DeviceAuthAuthorize storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthAuthorize) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthAuthorize", `
+		UPDATE oauth2_device_flow
+		SET user_id = ?, authorized = 1, token_description = ?, scopes = ?
+		WHERE device_code = ? AND authorized = 0 AND denied = 0`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthAuthorize) run(userID int64, deviceCode, tokenDescription, scopes string) error {
+	_, err := s.Stmt.Exec(userID, tokenDescription, scopes, deviceCode)
+	return err
+}
+
+type stmtOAuth2DeviceAuthDeny storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthDeny) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthDeny", `
+		UPDATE oauth2_device_flow
+		SET denied = 1
+		WHERE device_code = ? AND authorized = 0 AND denied = 0`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthDeny) run(deviceCode string) error {
+	_, err := s.Stmt.Exec(deviceCode)
+	return err
+}
+
+type stmtOAuth2DeviceAuthDelete storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthDelete) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthDelete", `
+		DELETE FROM oauth2_device_flow
+		WHERE device_code = ?`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthDelete) run(deviceCode string) error {
+	_, err := s.Stmt.Exec(deviceCode)
+	return err
+}
+
+type stmtOAuth2DeviceAuthDeleteExpired storage.DbStmt
+
+func (s *stmtOAuth2DeviceAuthDeleteExpired) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("oauth2DeviceAuthDeleteExpired", `
+		DELETE FROM oauth2_device_flow
+		WHERE expires_at < ?`,
+	)
+	return
+}
+
+func (s *stmtOAuth2DeviceAuthDeleteExpired) run(before int64) error {
+	_, err := s.Stmt.Exec(before)
+	return err
+}

--- a/storage/users/user_storage.go
+++ b/storage/users/user_storage.go
@@ -180,6 +180,17 @@ func (s Storage) Get(username string) (*User, error) {
 	return u, err
 }
 
+func (s Storage) GetByID(id int64) (*User, error) {
+	u, err := s.stmtUserGetById.run(id)
+	switch err {
+	case sql.ErrNoRows:
+		return nil, nil
+	case nil:
+		u.h = s
+	}
+	return u, err
+}
+
 func (s Storage) List() ([]User, error) {
 	users, err := s.stmtUserList.run()
 	if err == nil {

--- a/storage/users/user_storage.go
+++ b/storage/users/user_storage.go
@@ -73,6 +73,15 @@ type Storage struct {
 	stmtTokenDeleteExpired stmtTokenDeleteExpired
 	stmtTokenList          stmtTokenList
 	stmtTokenLookup        stmtTokenLookup
+
+	// OAuth2 device-flow authorization
+	stmtOAuth2DeviceAuthCreate          stmtOAuth2DeviceAuthCreate
+	stmtOAuth2DeviceAuthGetByDeviceCode stmtOAuth2DeviceAuthGetByDeviceCode
+	stmtOAuth2DeviceAuthGetByUserCode   stmtOAuth2DeviceAuthGetByUserCode
+	stmtOAuth2DeviceAuthAuthorize       stmtOAuth2DeviceAuthAuthorize
+	stmtOAuth2DeviceAuthDeny            stmtOAuth2DeviceAuthDeny
+	stmtOAuth2DeviceAuthDelete          stmtOAuth2DeviceAuthDelete
+	stmtOAuth2DeviceAuthDeleteExpired   stmtOAuth2DeviceAuthDeleteExpired
 }
 
 func NewStorage(db *storage.DbHandle, fs *storage.FsHandle, authConfig *storage.AuthConfig) (*Storage, error) {
@@ -103,6 +112,13 @@ func NewStorage(db *storage.DbHandle, fs *storage.FsHandle, authConfig *storage.
 		&handle.stmtTokenDeleteExpired,
 		&handle.stmtTokenList,
 		&handle.stmtTokenLookup,
+		&handle.stmtOAuth2DeviceAuthCreate,
+		&handle.stmtOAuth2DeviceAuthGetByDeviceCode,
+		&handle.stmtOAuth2DeviceAuthGetByUserCode,
+		&handle.stmtOAuth2DeviceAuthAuthorize,
+		&handle.stmtOAuth2DeviceAuthDeny,
+		&handle.stmtOAuth2DeviceAuthDelete,
+		&handle.stmtOAuth2DeviceAuthDeleteExpired,
 	); err != nil {
 		return nil, err
 	}
@@ -120,6 +136,11 @@ func (s Storage) RunGc() {
 	slog.Info("Running user session GC")
 	if err := s.stmtSessionDeleteExpired.run(now); err != nil {
 		slog.Error("Unable to run user session GC", "error", err)
+	}
+
+	slog.Info("Running OAuth2 device-flow GC")
+	if err := s.stmtOAuth2DeviceAuthDeleteExpired.run(now); err != nil {
+		slog.Error("Unable to run OAuth2 device-flow GC", "error", err)
 	}
 }
 

--- a/storage/users/user_storage_test.go
+++ b/storage/users/user_storage_test.go
@@ -229,3 +229,120 @@ func TestGc(t *testing.T) {
 	require.Nil(t, err)
 	require.Nil(t, u2)
 }
+
+func TestOAuth2DeviceFlow(t *testing.T) {
+	tmpdir := t.TempDir()
+	dbFile := filepath.Join(tmpdir, "sql.db")
+	db, err := storage.NewDb(dbFile)
+	require.Nil(t, err)
+	fs, err := storage.NewFs(tmpdir)
+	require.Nil(t, err)
+	require.Nil(t, fs.Auth.InitHmacSecret())
+
+	users, err := NewStorage(db, fs, &storage.AuthConfig{})
+	require.Nil(t, err)
+	require.NotNil(t, users)
+
+	u := User{
+		Username:      "testuser",
+		Password:      "passwordhash",
+		Email:         "testuser@example.com",
+		AllowedScopes: ScopeDevicesRU,
+	}
+	err = users.Create(&u)
+	require.Nil(t, err)
+
+	// Test creating device authorization
+	now := time.Now().Unix()
+	expiresAt := now + 600     // 10 minutes
+	tokenExpires := now + 3600 // 1 hour
+	scopes := "devices:read"
+
+	deviceCode, userCode, err := users.CreateDeviceAuth(expiresAt, tokenExpires, scopes)
+	require.Nil(t, err)
+
+	// Test getting device auth by device code
+	auth, err := users.GetDeviceAuthByDeviceCode(deviceCode)
+	require.Nil(t, err)
+	require.NotNil(t, auth)
+	require.Equal(t, deviceCode, auth.DeviceCode)
+	require.Equal(t, userCode, auth.UserCode)
+	require.Equal(t, expiresAt, auth.ExpiresAt)
+	require.Equal(t, tokenExpires, auth.TokenExpires)
+	require.Equal(t, scopes, auth.Scopes)
+	require.Nil(t, auth.UserID)
+	require.False(t, auth.Authorized)
+	require.False(t, auth.Denied)
+
+	// Test getting device auth by user code
+	auth2, err := users.GetDeviceAuthByUserCode(userCode)
+	require.Nil(t, err)
+	require.NotNil(t, auth2)
+	require.Equal(t, deviceCode, auth2.DeviceCode)
+	require.Equal(t, userCode, auth2.UserCode)
+
+	// Test getting non-existent device auth
+	auth3, err := users.GetDeviceAuthByDeviceCode("nonexistent")
+	require.Nil(t, err)
+	require.Nil(t, auth3)
+
+	auth4, err := users.GetDeviceAuthByUserCode("ZZZZ-ZZZZ")
+	require.Nil(t, err)
+	require.Nil(t, auth4)
+
+	// Test approving authorization
+	err = u.ApproveAuthorization(deviceCode, "test token description", ScopeDevicesR)
+	require.Nil(t, err)
+
+	auth5, err := users.GetDeviceAuthByDeviceCode(deviceCode)
+	require.Nil(t, err)
+	require.NotNil(t, auth5)
+	require.True(t, auth5.Authorized)
+	require.False(t, auth5.Denied)
+	require.NotNil(t, auth5.UserID)
+	require.Equal(t, u.id, *auth5.UserID)
+	require.Equal(t, "test token description", auth5.TokenDescription)
+
+	// Create another device auth for deny test
+	deviceCode2, _, err := users.CreateDeviceAuth(expiresAt, tokenExpires, scopes)
+	require.Nil(t, err)
+
+	// Test denying authorization
+	err = u.DenyDeviceAuth(deviceCode2)
+	require.Nil(t, err)
+
+	auth6, err := users.GetDeviceAuthByDeviceCode(deviceCode2)
+	require.Nil(t, err)
+	require.NotNil(t, auth6)
+	require.False(t, auth6.Authorized)
+	require.True(t, auth6.Denied)
+	require.Nil(t, auth6.UserID)
+
+	// Test deleting expired device auth entries
+	expiredExpiresAt := now - 600
+	deviceCode3, _, err := users.CreateDeviceAuth(expiredExpiresAt, tokenExpires, scopes)
+	require.Nil(t, err)
+
+	// Verify it exists
+	auth7, err := users.GetDeviceAuthByDeviceCode(deviceCode3)
+	require.Nil(t, err)
+	require.NotNil(t, auth7)
+
+	// Delete expired entries
+	err = users.DeleteExpiredDeviceAuth(now)
+	require.Nil(t, err)
+
+	// Verify expired entry is gone
+	auth8, err := users.GetDeviceAuthByDeviceCode(deviceCode3)
+	require.Nil(t, err)
+	require.Nil(t, auth8)
+
+	// Verify non-expired entries still exist
+	auth9, err := users.GetDeviceAuthByDeviceCode(deviceCode)
+	require.Nil(t, err)
+	require.NotNil(t, auth9)
+
+	auth10, err := users.GetDeviceAuthByDeviceCode(deviceCode2)
+	require.Nil(t, err)
+	require.NotNil(t, auth10)
+}


### PR DESCRIPTION
This set of changes adds support for oauth2 device flow to streamline the CLI login process. It also sets the basis for followup work to support lmp-device-register