### PR TITLE
tuf: Support importing root keys from a fioctl tarball

### DIFF
--- a/cmd/server/tuf_init.go
+++ b/cmd/server/tuf_init.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/foundriesio/update-server/storage"
@@ -49,9 +50,39 @@ func (c TufInitCmd) Run(args CommonArgs) error {
 		if err != nil {
 			return err
 		}
-		return fs.Tuf.ImportTuf(roots, keys)
+		if err := fs.Tuf.ImportTuf(roots, keys); err != nil {
+			return err
+		}
+		printRootKeyBackupNotice(fs)
+		return nil
 	}
-	return fs.Tuf.InitTuf()
+	if err := fs.Tuf.InitTuf(); err != nil {
+		return err
+	}
+	printRootKeyBackupNotice(fs)
+	return nil
+}
+
+// printRootKeyBackupNotice warns the operator that the newly created root key
+// is irreplaceable and must be backed up along with the HMAC secret used to
+// decrypt it.
+func printRootKeyBackupNotice(fs *storage.FsHandle) {
+	rootKeyPath := filepath.Join(fs.Config.TufDir(), "keys", "root.key")
+	hmacPath := filepath.Join(fs.Config.AuthDir(), storage.HmacFile)
+	fmt.Println()
+	fmt.Println("TUF initialization completed successfully.")
+	fmt.Println()
+	fmt.Println("IMPORTANT: A new root key was created at:")
+	fmt.Printf("    %s\n", rootKeyPath)
+	fmt.Println()
+	fmt.Println("This key is encrypted at rest using the HMAC secret at:")
+	fmt.Printf("    %s\n", hmacPath)
+	fmt.Println()
+	fmt.Println("Make a backup copy of BOTH files and store them somewhere safe NOW.")
+	fmt.Println("The root key is useless without the HMAC secret needed to decrypt it.")
+	fmt.Println("If either file is lost it CANNOT be recovered, and you will permanently")
+	fmt.Println("lose the ability to rotate or manage your TUF root of trust.")
+	fmt.Println()
 }
 
 // loadTufKeysArchive opens a fioctl offline keys tarball and extracts the

--- a/cmd/server/tuf_init.go
+++ b/cmd/server/tuf_init.go
@@ -4,15 +4,140 @@
 package main
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/foundriesio/update-server/storage"
+	"github.com/foundriesio/update-server/storage/tuf"
 )
 
-type TufInitCmd struct{}
+// rootJsonSuffix is the suffix ota-tuf uses for root metadata files (e.g.
+// "1.root.json").
+const rootJsonSuffix = ".root.json"
+
+// tufKeyFileSuffix is the suffix fioctl/garage-sign use for private key files
+// stored in the offline keys tarball.
+const tufKeyFileSuffix = ".sec"
+
+type TufInitCmd struct {
+	ImportKeys  string `arg:"--import-keys" help:"Path to a fioctl offline keys tarball with the root key(s) to sign the rotation; enables TUF root import (requires auth-init to have been run first)"`
+	ImportRoots string `arg:"--import-roots" help:"Path to a gzipped tarball containing all root.json files to import"`
+}
 
 func (c TufInitCmd) Run(args CommonArgs) error {
 	fs, err := storage.NewFs(args.DataDir)
 	if err != nil {
 		return err
 	}
+	if c.ImportKeys != "" || c.ImportRoots != "" {
+		if c.ImportKeys == "" {
+			return fmt.Errorf("--import-keys is required to import TUF root metadata")
+		}
+		if c.ImportRoots == "" {
+			return fmt.Errorf("--import-roots is required to import TUF root metadata")
+		}
+		roots, err := loadTufRootsArchive(c.ImportRoots)
+		if err != nil {
+			return err
+		}
+		keys, err := loadTufKeysArchive(c.ImportKeys)
+		if err != nil {
+			return err
+		}
+		return fs.Tuf.ImportTuf(roots, keys)
+	}
 	return fs.Tuf.InitTuf()
+}
+
+// loadTufKeysArchive opens a fioctl offline keys tarball and extracts the
+// root key files it contains. Only private key files (those ending in
+// ".sec") are parsed; all other archive entries are ignored.
+func loadTufKeysArchive(path string) ([]tuf.AtsKey, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open keys archive: %w", err)
+	}
+	defer f.Close() // nolint:errcheck
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open keys archive (expected a gzipped tarball): %w", err)
+	}
+	defer gz.Close() // nolint:errcheck
+
+	var keys []tuf.AtsKey
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("unable to read keys archive: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeDir || !strings.HasSuffix(hdr.Name, tufKeyFileSuffix) {
+			continue
+		}
+
+		if data, err := io.ReadAll(tr); err != nil {
+			return nil, fmt.Errorf("unable to read %s from keys archive: %w", hdr.Name, err)
+		} else {
+			var key tuf.AtsKey
+			if err := json.Unmarshal(data, &key); err != nil {
+				return nil, fmt.Errorf("unable to parse key file %s: %w", hdr.Name, err)
+			}
+			if key.KeyType != "" && key.KeyValue.Private != "" {
+				keys = append(keys, key)
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("keys archive does not contain any valid private key files (expected .sec files with private key material)")
+	}
+	return keys, nil
+}
+
+// loadTufRootsArchive reads a gzipped tar archive and returns the raw bytes of
+// every root.json file it contains. Only files ending in ".root.json" are
+// extracted; all other archive entries are ignored.
+func loadTufRootsArchive(path string) ([][]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open roots archive: %w", err)
+	}
+	defer f.Close() // nolint:errcheck
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open roots archive (expected a gzipped tarball): %w", err)
+	}
+	defer gz.Close() // nolint:errcheck
+
+	var roots [][]byte
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("unable to read roots archive: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeDir || !strings.HasSuffix(hdr.Name, rootJsonSuffix) {
+			continue
+		}
+
+		if data, err := io.ReadAll(tr); err != nil {
+			return nil, fmt.Errorf("unable to read %s from roots archive: %w", hdr.Name, err)
+		} else {
+			roots = append(roots, data)
+		}
+	}
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("roots archive does not contain any root.json files (expected files ending in %q)", rootJsonSuffix)
+	}
+	return roots, nil
 }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -69,6 +69,42 @@ root metadata must be initialized:
   ./fioserver --datadir=./datadir tuf-init
 ```
 
+### Importing an existing fleet's TUF root
+
+If you already have a fleet of devices provisioned against a Foundries.io
+factory, initializing a brand new TUF root would leave those devices unable
+to validate metadata from this server. Instead, you can import the factory's
+existing root of trust so that already-provisioned devices continue to trust
+updates.
+
+The import reads every version of the factory's `root.json` from a tarball you
+provide, stores them so devices can walk the trust chain, and then generates a
+new root (version N+1) with fresh online keys for the `root`, `targets`,
+`snapshot`, and `timestamp` roles. The new root is signed by both the factory's
+offline root key (proving continuity of trust) and the new root key.
+
+You will need:
+
+* The factory's offline keys tarball (typically `offline-creds.tgz`),
+  which contains the offline root key used to sign the rotation.
+* A gzipped tarball containing all of the factory's `root.json` files (e.g.
+  `1.root.json`, `2.root.json`, ...). See `fioctl keys tuf show-root`.
+```
+  ./fioserver --datadir=./datadir tuf-init \
+    --import-keys ./offline-creds.tgz \
+    --import-roots ./roots.tgz
+```
+
+Options:
+
+* `--import-keys` — path to the fioctl offline keys tarball. Providing this
+  (or `--import-roots`) enables import mode.
+* `--import-roots` — path to a gzipped tarball containing all of the factory's
+  `root.json` files. See `fioctl keys tuf download-roots`.
+
+> **Note:** `tuf-init` requires `auth-init` to have been run first so that the
+> imported role keys can be encrypted at rest.
+
 ## Run the Server
 
 `./fioserv serve --datadir=datadir`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -105,6 +105,14 @@ Options:
 > **Note:** `tuf-init` requires `auth-init` to have been run first so that the
 > imported role keys can be encrypted at rest.
 
+> **IMPORTANT:** A successful import generates a new root key at
+> `<datadir>/tufrepo/keys/root.key`. This key is encrypted at rest using the
+> HMAC secret at `<datadir>/auth/hmac.secret`, so you must back up BOTH files —
+> the `root.key` is useless without the `hmac.secret` needed to decrypt it.
+> Store copies of both somewhere safe immediately. If either file is lost it
+> CANNOT be recovered, and you will permanently lose the ability to rotate or
+> manage your TUF root of trust.
+
 ## Run the Server
 
 `./fioserv serve --datadir=datadir`

--- a/storage/file_tuf_import.go
+++ b/storage/file_tuf_import.go
@@ -91,8 +91,7 @@ func (h TufFsHandle) importTuf(roots []importedRoot, candidateKeys []tuf.AtsKey)
 		return fmt.Errorf("imported root.json (version %d) has no root role", base.root.Signed.Version)
 	}
 
-	// Find the offline root signer(s) matching the imported root role key ids.
-	oldSigners, err := matchRootSigners(oldRootRole.KeyIDs, candidateKeys)
+	oldSigner, err := findFirstRootSigner(oldRootRole.KeyIDs, candidateKeys)
 	if err != nil {
 		return err
 	}
@@ -140,15 +139,11 @@ func (h TufFsHandle) importTuf(roots []importedRoot, candidateKeys []tuf.AtsKey)
 	if err != nil {
 		return fmt.Errorf("unable to sign new root metadata: %w", err)
 	}
-	signatures := []tuf.Signature{newSigned}
-	for _, old := range oldSigners {
-		oldSigned, err := old.Sign(newRoot.Signed)
-		if err != nil {
-			return fmt.Errorf("unable to sign new root metadata with imported key %s: %w", old.Id, err)
-		}
-		signatures = append(signatures, oldSigned)
+	oldSigned, err := oldSigner.Sign(newRoot.Signed)
+	if err != nil {
+		return fmt.Errorf("unable to sign new root metadata with imported key %s: %w", oldSigner.Id, err)
 	}
-	newRoot.Signatures = signatures
+	newRoot.Signatures = []tuf.Signature{newSigned, oldSigned}
 
 	// Persist every imported root verbatim, then the newly generated root.
 	if err := h.mkdirs(defaultDirAccess, true); err != nil {
@@ -163,31 +158,16 @@ func (h TufFsHandle) importTuf(roots []importedRoot, candidateKeys []tuf.AtsKey)
 	return h.writeRoot(newRoot)
 }
 
-// matchRootSigners returns an ImportSigner for every candidate private key
-// whose key id is listed in keyIDs. It errors if no matching key is found.
-func matchRootSigners(keyIDs []string, candidateKeys []tuf.AtsKey) ([]*tuf.ImportSigner, error) {
-	wanted := make(map[string]bool, len(keyIDs))
-	for _, id := range keyIDs {
-		wanted[id] = true
-	}
-
-	var signers []*tuf.ImportSigner
+func findFirstRootSigner(keyIDs []string, candidateKeys []tuf.AtsKey) (*tuf.ImportSigner, error) {
 	for _, key := range candidateKeys {
 		signer, err := tuf.ImportSignerFromAtsKey(key)
 		if err != nil {
 			// Not a usable signing key (e.g. public-only or unsupported type).
 			continue
 		}
-		if wanted[signer.Id] {
-			signers = append(signers, signer)
-			delete(wanted, signer.Id)
+		if slices.Contains(keyIDs, signer.Id) {
+			return signer, nil
 		}
 	}
-	if len(signers) == 0 {
-		return nil, fmt.Errorf(
-			"keys archive does not contain a private key for any of the root role key ids: %v",
-			keyIDs,
-		)
-	}
-	return signers, nil
+	return nil, fmt.Errorf("unable to find root key signer for key IDs: %v", keyIDs)
 }

--- a/storage/file_tuf_import.go
+++ b/storage/file_tuf_import.go
@@ -1,0 +1,193 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/foundriesio/update-server/clock"
+	"github.com/foundriesio/update-server/storage/tuf"
+)
+
+// importedRoot holds the imported root metadata along with its raw bytes. The
+// raw bytes are stored verbatim so the original signatures remain verifiable.
+type importedRoot struct {
+	raw  []byte
+	root tuf.AtsTufRoot
+}
+
+// ImportTuf initializes TUF for this server by migrating from an existing
+// fioctl/ota-tuf setup.
+//
+// rootJSONs are the raw bytes of every known root.json version. candidateKeys
+// are the private keys extracted from a fioctl offline keys tarball,
+// including the offline private key(s) for the root role. Every imported
+// root.json is stored verbatim, fresh online keys are generated for every role,
+// and a new root.json (version = highest imported version + 1) is created and
+// signed by both the imported (old) root key(s) and the newly generated root
+// key so that clients can verify the chain of trust from the previously
+// trusted root.
+//
+// It fails if TUF data already exists.
+func (h TufFsHandle) ImportTuf(rootJSONs [][]byte, candidateKeys []tuf.AtsKey) error {
+	if h.isInitialized() {
+		return ErrTufAlreadyInitialized
+	}
+
+	if len(rootJSONs) == 0 {
+		return fmt.Errorf("no root metadata was provided to import")
+	}
+	roots := make([]importedRoot, 0, len(rootJSONs))
+	for _, raw := range rootJSONs {
+		var root tuf.AtsTufRoot
+		if err := json.Unmarshal(raw, &root); err != nil {
+			return fmt.Errorf("unable to parse root metadata: %w", err)
+		}
+		if len(root.Signed.Roles) == 0 {
+			return fmt.Errorf("provided metadata does not look like a TUF root.json")
+		}
+		roots = append(roots, importedRoot{raw: raw, root: root})
+	}
+
+	return h.importTuf(roots, candidateKeys)
+}
+
+// importTuf performs the actual import once the root metadata and keys have
+// been parsed.
+func (h TufFsHandle) importTuf(roots []importedRoot, candidateKeys []tuf.AtsKey) error {
+	hmacSecret, err := h.auth.GetHmacSecret()
+	if err != nil {
+		return fmt.Errorf("unable to read HMAC secret (run auth-init first): %w", err)
+	} else if len(hmacSecret) == 0 {
+		return fmt.Errorf("HMAC secret is empty; run auth-init first")
+	}
+
+	// The highest-version imported root is the trust anchor to chain from.
+	slices.SortFunc(roots, func(a, b importedRoot) int {
+		return a.root.Signed.Version - b.root.Signed.Version
+	})
+	base := roots[len(roots)-1]
+
+	// ensure we have all the root.json versions
+	for idx, root := range roots {
+		if idx+1 != root.root.Signed.Version {
+			return fmt.Errorf("missing %d.root.json version", idx+1)
+		}
+	}
+
+	rootThresh := base.root.Signed.Roles[tuf.RoleRoot].Threshold
+	if rootThresh > 1 {
+		return fmt.Errorf("unable to import TUF root. The signature threshold for the root role must be 1. Current value is: %d", rootThresh)
+	}
+
+	oldRootRole, ok := base.root.Signed.Roles[tuf.RoleRoot]
+	if !ok {
+		return fmt.Errorf("imported root.json (version %d) has no root role", base.root.Signed.Version)
+	}
+
+	// Find the offline root signer(s) matching the imported root role key ids.
+	oldSigners, err := matchRootSigners(oldRootRole.KeyIDs, candidateKeys)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(h.keysDir(), defaultDirAccess); err != nil {
+		return fmt.Errorf("unable to create TUF keys directory: %w", err)
+	}
+
+	// Generate fresh online keys for every role owned by this server.
+	signers := make(map[tuf.RoleName]*tuf.Signer, len(tufRoles))
+	for _, role := range tufRoles {
+		signer, err := tuf.NewSigner()
+		if err != nil {
+			return fmt.Errorf("unable to generate %s key: %w", role, err)
+		}
+		if err := h.writeKey(hmacSecret, role, signer); err != nil {
+			return err
+		}
+		signers[role] = signer
+	}
+
+	keys := make(map[string]tuf.AtsKey, len(signers))
+	roles := make(map[tuf.RoleName]tuf.RootRole, len(signers))
+	for _, role := range tufRoles {
+		signer := signers[role]
+		keys[signer.Id] = signer.PublicAtsKey()
+		roles[role] = tuf.RootRole{KeyIDs: []string{signer.Id}, Threshold: 1}
+	}
+	newRoot := tuf.AtsTufRoot{
+		Signed: tuf.RootMeta{
+			SignedCommon: tuf.SignedCommon{
+				Type:    tuf.RoleRoot.TufType(),
+				Expires: clock.Now().UTC().Add(h.RootExpiration).Truncate(time.Second),
+				Version: base.root.Signed.Version + 1,
+			},
+			ConsistentSnapshot: false,
+			Keys:               keys,
+			Roles:              roles,
+		},
+	}
+
+	// The new root must be signed by the new root key and one matching old
+	// root key so it chains from the previously trusted root.
+	newSigned, err := signers[tuf.RoleRoot].Sign(newRoot.Signed)
+	if err != nil {
+		return fmt.Errorf("unable to sign new root metadata: %w", err)
+	}
+	signatures := []tuf.Signature{newSigned}
+	for _, old := range oldSigners {
+		oldSigned, err := old.Sign(newRoot.Signed)
+		if err != nil {
+			return fmt.Errorf("unable to sign new root metadata with imported key %s: %w", old.Id, err)
+		}
+		signatures = append(signatures, oldSigned)
+	}
+	newRoot.Signatures = signatures
+
+	// Persist every imported root verbatim, then the newly generated root.
+	if err := h.mkdirs(defaultDirAccess, true); err != nil {
+		return fmt.Errorf("unable to create TUF directory: %w", err)
+	}
+	for _, imp := range roots {
+		name := strconv.Itoa(imp.root.Signed.Version) + rootJsonSuffix
+		if err := h.writeFile(name, string(imp.raw), defaultFileAccess); err != nil {
+			return fmt.Errorf("unable to write %s: %w", name, err)
+		}
+	}
+	return h.writeRoot(newRoot)
+}
+
+// matchRootSigners returns an ImportSigner for every candidate private key
+// whose key id is listed in keyIDs. It errors if no matching key is found.
+func matchRootSigners(keyIDs []string, candidateKeys []tuf.AtsKey) ([]*tuf.ImportSigner, error) {
+	wanted := make(map[string]bool, len(keyIDs))
+	for _, id := range keyIDs {
+		wanted[id] = true
+	}
+
+	var signers []*tuf.ImportSigner
+	for _, key := range candidateKeys {
+		signer, err := tuf.ImportSignerFromAtsKey(key)
+		if err != nil {
+			// Not a usable signing key (e.g. public-only or unsupported type).
+			continue
+		}
+		if wanted[signer.Id] {
+			signers = append(signers, signer)
+			delete(wanted, signer.Id)
+		}
+	}
+	if len(signers) == 0 {
+		return nil, fmt.Errorf(
+			"keys archive does not contain a private key for any of the root role key ids: %v",
+			keyIDs,
+		)
+	}
+	return signers, nil
+}

--- a/storage/file_tuf_import_test.go
+++ b/storage/file_tuf_import_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package storage
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/foundriesio/update-server/storage/tuf"
+	"github.com/secure-systems-lab/go-securesystemslib/cjson"
+	"github.com/stretchr/testify/require"
+)
+
+// keyID computes the ota-tuf key id (hex sha256 of PKIX DER) for a public key.
+func keyID(t *testing.T, pub crypto.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
+
+// buildEd25519Import builds a root.json (at the given version) whose root role
+// is held by a freshly generated ed25519 offline key, plus that key's
+// AtsKey (private) form. It returns the raw root.json bytes, the candidate
+// keys to pass to ImportTuf, and the root role's public key.
+func buildEd25519Import(t *testing.T, version int) (rootBytes []byte, keys []tuf.AtsKey, oldPub ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	kid := keyID(t, pub)
+
+	pubKey := tuf.AtsKey{KeyType: "ED25519", KeyValue: tuf.AtsKeyVal{Public: hex.EncodeToString(pub)}}
+	secKey := tuf.AtsKey{KeyType: "ED25519", KeyValue: tuf.AtsKeyVal{Private: hex.EncodeToString(priv.Seed())}}
+
+	root := buildRoot(t, version, kid, pubKey)
+	// Sign the imported root with its own root key so it is self-consistent.
+	msg, err := cjson.EncodeCanonical(root.Signed)
+	require.NoError(t, err)
+	sig := ed25519.Sign(priv, msg)
+	root.Signatures = []tuf.Signature{{KeyID: kid, Method: tuf.SigEd25519, Signature: sig}}
+
+	rootBytes, err = json.MarshalIndent(root, "", "  ")
+	require.NoError(t, err)
+
+	return rootBytes, []tuf.AtsKey{secKey}, pub
+}
+
+// buildRSAImport builds a root.json and candidate keys whose root role is
+// held by a freshly generated RSA offline key.
+func buildRSAImport(t *testing.T, version int) (rootBytes []byte, keys []tuf.AtsKey, oldPub *rsa.PublicKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	kid := keyID(t, &priv.PublicKey)
+
+	pubDer, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	pubPem := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer}))
+	privPem := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}))
+
+	pubKey := tuf.AtsKey{KeyType: "RSA", KeyValue: tuf.AtsKeyVal{Public: pubPem}}
+	secKey := tuf.AtsKey{KeyType: "RSA", KeyValue: tuf.AtsKeyVal{Private: privPem}}
+
+	root := buildRoot(t, version, kid, pubKey)
+	rootBytes, err = json.MarshalIndent(root, "", "  ")
+	require.NoError(t, err)
+
+	return rootBytes, []tuf.AtsKey{secKey}, &priv.PublicKey
+}
+
+// buildRoot builds a minimal root metadata whose root role uses the given key
+// and with placeholder online keys for the other roles.
+func buildRoot(t *testing.T, version int, rootKeyID string, rootKey tuf.AtsKey) tuf.AtsTufRoot {
+	t.Helper()
+	keys := map[string]tuf.AtsKey{rootKeyID: rootKey}
+	roles := map[tuf.RoleName]tuf.RootRole{
+		tuf.RoleRoot: {KeyIDs: []string{rootKeyID}, Threshold: 1},
+	}
+	for _, role := range []tuf.RoleName{tuf.RoleTargets, tuf.RoleSnapshot, tuf.RoleTimestamp} {
+		pub, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		kid := keyID(t, pub)
+		keys[kid] = tuf.AtsKey{KeyType: "ED25519", KeyValue: tuf.AtsKeyVal{Public: hex.EncodeToString(pub)}}
+		roles[role] = tuf.RootRole{KeyIDs: []string{kid}, Threshold: 1}
+	}
+	return tuf.AtsTufRoot{
+		Signed: tuf.RootMeta{
+			SignedCommon: tuf.SignedCommon{Type: tuf.RoleRoot.TufType(), Version: version},
+			Keys:         keys,
+			Roles:        roles,
+		},
+	}
+}
+
+func TestImportTufEd25519(t *testing.T) {
+	fs := newTufTestFs(t)
+	// All root versions must be present, so import a contiguous 1..3 chain.
+	// The highest version (3) is the trust anchor the rotation chains from.
+	rootV1, _, _ := buildEd25519Import(t, 1)
+	rootV2, _, _ := buildEd25519Import(t, 2)
+	rootBytes, keys, oldPub := buildEd25519Import(t, 3)
+
+	require.NoError(t, fs.Tuf.ImportTuf([][]byte{rootV1, rootV2, rootBytes}, keys))
+	require.True(t, fs.Tuf.isInitialized())
+
+	// The imported roots (v1-v3) are stored verbatim and a new root (v4) is created.
+	for _, v := range []string{"1.root.json", "2.root.json", "3.root.json", "4.root.json"} {
+		_, err := os.Stat(filepath.Join(fs.Config.TufDir(), v))
+		require.NoError(t, err, v)
+	}
+
+	roots, err := fs.Tuf.GetRoots()
+	require.NoError(t, err)
+	require.Len(t, roots, 4)
+	newRoot := roots[3]
+	require.Equal(t, 4, newRoot.Signed.Version)
+	require.Len(t, newRoot.Signed.Roles, len(tufRoles))
+
+	// New root must have two signatures: the new root key and the old root key.
+	require.Len(t, newRoot.Signatures, 2)
+	oldKid := keyID(t, oldPub)
+	newKid := newRoot.Signed.Roles[tuf.RoleRoot].KeyIDs[0]
+	require.NotEqual(t, oldKid, newKid)
+
+	msg, err := cjson.EncodeCanonical(newRoot.Signed)
+	require.NoError(t, err)
+
+	sigs := map[string]tuf.Signature{}
+	for _, s := range newRoot.Signatures {
+		sigs[s.KeyID] = s
+	}
+	// Old root key signature verifies over the new canonical payload.
+	require.Contains(t, sigs, oldKid)
+	require.True(t, ed25519.Verify(oldPub, msg, sigs[oldKid].Signature))
+
+	// New root key signature verifies too.
+	require.Contains(t, sigs, newKid)
+	newPub, err := hex.DecodeString(newRoot.Signed.Keys[newKid].KeyValue.Public)
+	require.NoError(t, err)
+	require.True(t, ed25519.Verify(ed25519.PublicKey(newPub), msg, sigs[newKid].Signature))
+
+	// The old root key is not retained in the new root's key set.
+	require.NotContains(t, newRoot.Signed.Keys, oldKid)
+
+	// Server keys load and match the new root.
+	require.NoError(t, fs.Tuf.LoadTuf())
+	require.Equal(t, newKid, fs.Tuf.signers[tuf.RoleRoot].Id)
+}
+
+func TestImportTufRSA(t *testing.T) {
+	fs := newTufTestFs(t)
+	rootBytes, keys, oldPub := buildRSAImport(t, 1)
+
+	require.NoError(t, fs.Tuf.ImportTuf([][]byte{rootBytes}, keys))
+
+	roots, err := fs.Tuf.GetRoots()
+	require.NoError(t, err)
+	require.Len(t, roots, 2)
+	newRoot := roots[1]
+	require.Equal(t, 2, newRoot.Signed.Version)
+	require.Len(t, newRoot.Signatures, 2)
+
+	oldKid := keyID(t, oldPub)
+	msg, err := cjson.EncodeCanonical(newRoot.Signed)
+	require.NoError(t, err)
+	hashed := sha256.Sum256(msg)
+
+	var oldSig *tuf.Signature
+	for i := range newRoot.Signatures {
+		if newRoot.Signatures[i].KeyID == oldKid {
+			oldSig = &newRoot.Signatures[i]
+		}
+	}
+	require.NotNil(t, oldSig)
+	require.Equal(t, tuf.SigRsaPssSha256, oldSig.Method)
+	require.NoError(t, rsa.VerifyPSS(oldPub, crypto.SHA256, hashed[:], oldSig.Signature,
+		&rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256}))
+}
+
+func TestImportTufFailsWhenInitialized(t *testing.T) {
+	fs := newTufTestFs(t)
+	require.NoError(t, fs.Tuf.InitTuf())
+	rootBytes, keys, _ := buildEd25519Import(t, 1)
+	require.ErrorIs(t, fs.Tuf.ImportTuf([][]byte{rootBytes}, keys), ErrTufAlreadyInitialized)
+}
+
+func TestImportTufMissingRootKey(t *testing.T) {
+	fs := newTufTestFs(t)
+
+	// Build a root but only supply the public key (no private key material).
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	kid := keyID(t, pub)
+	pubKey := tuf.AtsKey{KeyType: "ED25519", KeyValue: tuf.AtsKeyVal{Public: hex.EncodeToString(pub)}}
+	root := buildRoot(t, 1, kid, pubKey)
+	rootBytes, err := json.MarshalIndent(root, "", "  ")
+	require.NoError(t, err)
+
+	err = fs.Tuf.ImportTuf([][]byte{rootBytes}, []tuf.AtsKey{pubKey})
+	require.ErrorContains(t, err, "does not contain a private key for any of the root role key ids")
+	require.False(t, fs.Tuf.isInitialized())
+}
+
+func TestImportTufStoresAllVersions(t *testing.T) {
+	fs := newTufTestFs(t)
+
+	// An earlier version (1) is provided too and must be stored verbatim. The
+	// latest version (2) is built last so its keys are the ones used to sign
+	// the rotation.
+	rootV1, _, _ := buildEd25519Import(t, 1)
+	rootV2, keys, _ := buildEd25519Import(t, 2)
+
+	require.NoError(t, fs.Tuf.ImportTuf([][]byte{rootV2, rootV1}, keys))
+
+	for _, v := range []string{"1.root.json", "2.root.json", "3.root.json"} {
+		_, err := os.Stat(filepath.Join(fs.Config.TufDir(), v))
+		require.NoError(t, err, v)
+	}
+
+	// The stored v1/v2 files match the provided bytes verbatim.
+	storedV1, err := os.ReadFile(filepath.Join(fs.Config.TufDir(), "1.root.json"))
+	require.NoError(t, err)
+	require.Equal(t, rootV1, storedV1)
+}

--- a/storage/file_tuf_import_test.go
+++ b/storage/file_tuf_import_test.go
@@ -209,7 +209,7 @@ func TestImportTufMissingRootKey(t *testing.T) {
 	require.NoError(t, err)
 
 	err = fs.Tuf.ImportTuf([][]byte{rootBytes}, []tuf.AtsKey{pubKey})
-	require.ErrorContains(t, err, "does not contain a private key for any of the root role key ids")
+	require.ErrorContains(t, err, "unable to find root key signer for key IDs")
 	require.False(t, fs.Tuf.isInitialized())
 }
 

--- a/storage/tuf/tuf_import.go
+++ b/storage/tuf/tuf_import.go
@@ -1,0 +1,119 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package tuf
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/secure-systems-lab/go-securesystemslib/cjson"
+)
+
+// tufKeyTypeRSA is the keytype value used by ota-tuf for RSA keys.
+const tufKeyTypeRSA = "RSA"
+
+// ImportSigner wraps an offline private key (RSA or ed25519) imported from an
+// external tool such as fioctl/garage-sign. It is used to co-sign a newly
+// generated root metadata during migration so that the new root chains from
+// the previously trusted (imported) root.
+type ImportSigner struct {
+	Id     string
+	method SigAlgorithm
+	signer crypto.Signer
+	opts   crypto.SignerOpts
+}
+
+// ImportSignerFromAtsKey builds an ImportSigner from a private AtsKey. Both the
+// ota-tuf RSA (PEM PKCS#1) and ed25519 (hex) private key representations are
+// supported.
+func ImportSignerFromAtsKey(key AtsKey) (*ImportSigner, error) {
+	if key.KeyValue.Private == "" {
+		return nil, fmt.Errorf("TUF key is missing private material")
+	}
+	switch key.KeyType {
+	case tufKeyTypeEd25519:
+		seed, err := hex.DecodeString(key.KeyValue.Private)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ed25519 private key encoding: %w", err)
+		}
+		var priv ed25519.PrivateKey
+		switch len(seed) {
+		case ed25519.SeedSize:
+			priv = ed25519.NewKeyFromSeed(seed)
+		case ed25519.PrivateKeySize:
+			priv = ed25519.PrivateKey(seed)
+		default:
+			return nil, fmt.Errorf("invalid ed25519 private key size: %d", len(seed))
+		}
+		id, err := tufKeyID(priv.Public().(ed25519.PublicKey))
+		if err != nil {
+			return nil, err
+		}
+		return &ImportSigner{Id: id, method: SigEd25519, signer: priv, opts: crypto.Hash(0)}, nil
+	case tufKeyTypeRSA:
+		block, _ := pem.Decode([]byte(key.KeyValue.Private))
+		if block == nil {
+			return nil, fmt.Errorf("unable to decode RSA private key PEM")
+		}
+		priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse RSA private key: %w", err)
+		}
+		id, err := rsaKeyID(&priv.PublicKey)
+		if err != nil {
+			return nil, err
+		}
+		return &ImportSigner{
+			Id:     id,
+			method: SigRsaPssSha256,
+			signer: priv,
+			// ota-tuf/garage-sign sign RSA with RSASSA-PSS, SHA-256 and a salt
+			// length equal to the hash length.
+			opts: &rsa.PSSOptions{SaltLength: 32, Hash: crypto.SHA256},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported TUF key type: %s", key.KeyType)
+	}
+}
+
+// rsaKeyID computes the key id for an RSA public key the same way ota-tuf does:
+// the hex encoded sha256 of the key's canonical (PKIX/DER) public encoding.
+func rsaKeyID(pub *rsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("unable to marshal public key: %w", err)
+	}
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// Sign signs the canonical JSON of signed with the imported key and returns a
+// SignedMeta carrying the signature along with the sha256 hash and length of
+// the signed bytes.
+func (s *ImportSigner) Sign(signed any) (Signature, error) {
+	msg, err := cjson.EncodeCanonical(signed)
+	if err != nil {
+		return Signature{}, fmt.Errorf("unable to marshal canonical JSON: %w", err)
+	}
+	digest := msg
+	if h := s.opts.HashFunc(); h != crypto.Hash(0) {
+		// Golang expects the caller to hash the message for signing methods
+		// that use a hash (e.g. RSASSA-PSS).
+		hasher := h.New()
+		hasher.Write(msg)
+		digest = hasher.Sum(nil)
+	}
+	sig, err := s.signer.Sign(rand.Reader, digest, s.opts)
+	if err != nil {
+		return Signature{}, fmt.Errorf("unable to sign metadata: %w", err)
+	}
+	return Signature{KeyID: s.Id, Method: s.method, Signature: sig}, nil
+}


### PR DESCRIPTION
Add an optional --import-keys flag to the tuf-init command that reads a fioctl/ota-tuf tarball containing the offline root key(s) and root.json. The imported root.json files are stored verbatim, fresh online keys are generated for every role, and a new root.json is created and signed by both the imported (old) root key(s) and the new root key so clients can verify the chain of trust.

Chatting with Copilot on this, it was decided to be more efficient to use our own code for talking with the FIO backend for getting the root.json files rather than trying to integrate with the fioctl client library code.

Fixes bug #189