### PR TITLE
Improve the way we create a base page context

### DIFF
--- a/auth/noauth.go
+++ b/auth/noauth.go
@@ -24,7 +24,7 @@ func (noauthProvider) Name() string {
 	return "noauth"
 }
 
-func (p *noauthProvider) Configure(e *echo.Echo, storage *users.Storage, authConfig *storage.AuthConfig) (err error) {
+func (p *noauthProvider) Configure(e *echo.Echo, storage *users.Storage, authConfig *storage.AuthConfig, pageCtx PageContextBuilder) (err error) {
 	p.users = storage
 	p.scopes, err = users.ScopesFromSlice(authConfig.NewUserDefaultScopes)
 	return

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/foundriesio/update-server/server/ui/pagectx"
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/users"
 	"github.com/labstack/echo/v4"
@@ -21,6 +22,13 @@ type Session struct {
 	Client *http.Client
 }
 
+// PageContextBuilder builds the shared base.html page context. It is
+// implemented by the web layer and injected into providers so that provider
+// login pages are rendered from the same single source as every other page.
+type PageContextBuilder interface {
+	Base(c echo.Context, title, selected string) pagectx.Base
+}
+
 // Provider defines the interface that an authentication provider must implement
 // to support a web server's authentication needs. This interface works for basic
 // username/password authentication as well as OAuth2-based authentication.
@@ -30,7 +38,7 @@ type Provider interface {
 	// Configure can be used to:
 	//  - set up routes on the Echo instance
 	//  - initialize any provider-specific settings
-	Configure(e *echo.Echo, users *users.Storage, authConfig *storage.AuthConfig) error
+	Configure(e *echo.Echo, users *users.Storage, authConfig *storage.AuthConfig, pageCtx PageContextBuilder) error
 
 	// GetUser retrieves the user based on either an API token or session cookie.
 	GetUser(c echo.Context) (*users.User, error)
@@ -46,14 +54,14 @@ const AuthCallbackPath = "/auth/callback"
 
 var providers map[string]Provider
 
-func NewProvider(e *echo.Echo, db *storage.DbHandle, fs *storage.FsHandle, users *users.Storage) (Provider, error) {
+func NewProvider(e *echo.Echo, db *storage.DbHandle, fs *storage.FsHandle, users *users.Storage, pageCtx PageContextBuilder) (Provider, error) {
 	authConfig, err := fs.Auth.GetAuthConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get auth config: %w", err)
 	}
 
 	if provider, ok := providers[authConfig.Type]; ok {
-		if err := provider.Configure(e, users, authConfig); err != nil {
+		if err := provider.Configure(e, users, authConfig, pageCtx); err != nil {
 			return nil, fmt.Errorf("failed to configure provider `%s`: %w", authConfig.Type, err)
 		}
 		return provider, nil

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -22,6 +22,7 @@ type commonProvider struct {
 	users       *users.Storage
 	rateLimiter *authRateLimiter
 	renderer    loginPageRenderer
+	pageCtx     PageContextBuilder
 }
 
 func (p *commonProvider) DropSession(c echo.Context, session *Session) {

--- a/auth/provider_github.go
+++ b/auth/provider_github.go
@@ -28,7 +28,7 @@ type ghProvider struct {
 	AllowedOrgs []string
 }
 
-func (p *ghProvider) Configure(e *echo.Echo, users *users.Storage, cfg *storage.AuthConfig) error {
+func (p *ghProvider) Configure(e *echo.Echo, users *users.Storage, cfg *storage.AuthConfig, pageCtx PageContextBuilder) error {
 	var cfgGithub authConfigGithub
 	if err := json.Unmarshal(cfg.Config, &cfgGithub); err != nil {
 		return fmt.Errorf("unable to unmarshal github config: %w", err)
@@ -45,7 +45,7 @@ func (p *ghProvider) Configure(e *echo.Echo, users *users.Storage, cfg *storage.
 		},
 	}
 	p.loginTip = fmt.Sprintf("You must grant access to one of these organizations: %s", strings.Join(p.AllowedOrgs, ", "))
-	return p.configure(e, users, cfg)
+	return p.configure(e, users, cfg, pageCtx)
 }
 
 type ghProfile struct {

--- a/auth/provider_google.go
+++ b/auth/provider_google.go
@@ -29,7 +29,7 @@ type googleProvider struct {
 	AllowedDomains []string
 }
 
-func (p *googleProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg *storage.AuthConfig) error {
+func (p *googleProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg *storage.AuthConfig, pageCtx PageContextBuilder) error {
 	var cfgGoogle authConfigGoogle
 	if err := json.Unmarshal(cfg.Config, &cfgGoogle); err != nil {
 		return fmt.Errorf("unable to unmarshal google config: %w", err)
@@ -42,7 +42,7 @@ func (p *googleProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg
 		Scopes:       []string{"openid", "email", "profile"},
 		Endpoint:     google.Endpoint,
 	}
-	return p.configure(e, userStorage, cfg)
+	return p.configure(e, userStorage, cfg, pageCtx)
 }
 
 type googleUser struct {

--- a/auth/provider_local.go
+++ b/auth/provider_local.go
@@ -15,10 +15,10 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/foundriesio/update-server/server"
+	"github.com/foundriesio/update-server/server/ui/pagectx"
 	"github.com/foundriesio/update-server/server/ui/web/templates"
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/users"
-	"github.com/foundriesio/update-server/version"
 )
 
 const localLoginTemplate = "local-login.html"
@@ -58,7 +58,7 @@ func (p localProvider) Name() string {
 	return "local"
 }
 
-func (p *localProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg *storage.AuthConfig) error {
+func (p *localProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg *storage.AuthConfig, pageCtx PageContextBuilder) error {
 	if err := json.Unmarshal(cfg.Config, &p.authConfig); err != nil {
 		return fmt.Errorf("unable to unmarshal local config: %w", err)
 	}
@@ -66,6 +66,7 @@ func (p *localProvider) Configure(e *echo.Echo, userStorage *users.Storage, cfg 
 	p.users = userStorage
 	p.rateLimiter = NewRateLimiter(cfg.RateLimits)
 	p.renderer = p
+	p.pageCtx = pageCtx
 	p.sessionTimeout = time.Duration(cfg.SessionTimeoutHours) * time.Hour
 	p.newUserScopes, err = users.ScopesFromSlice(cfg.NewUserDefaultScopes)
 	if err != nil {
@@ -194,18 +195,13 @@ func (p localProvider) renderLoginPage(c echo.Context, reason string) error {
 	csrfToken := SetCsrfCookie(c, time.Now().Add(10*time.Minute))
 
 	context := struct {
-		Title     string
-		Reason    string
-		User      *users.User
-		NavItems  []string
-		CsrfToken string
-		Version   string
+		pagectx.Base
+		Reason string
 	}{
-		Title:     "Login",
-		Reason:    reason,
-		CsrfToken: csrfToken,
-		Version:   version.Version,
+		Base:   p.pageCtx.Base(c, "Login", ""),
+		Reason: reason,
 	}
+	context.CsrfToken = csrfToken
 	return templates.Templates.ExecuteTemplate(c.Response(), localLoginTemplate, context)
 }
 
@@ -239,24 +235,14 @@ func (p localProvider) GetSession(c echo.Context) (*Session, error) {
 }
 
 func (p *localProvider) handlePasswordPage(c echo.Context, session *Session) error {
-	var csrfToken string
-	if cookie, err := c.Cookie(CsrfCookieName); err == nil {
-		csrfToken = cookie.Value
-	}
 	context := struct {
-		Title     string
-		Message   string
-		User      *users.User
-		NavItems  []string
-		CsrfToken string
-		Version   string
+		pagectx.Base
+		Message string
 	}{
-		Title:     "Change Password",
-		Message:   "Your password has expired. Please choose a new password.",
-		User:      session.User,
-		CsrfToken: csrfToken,
-		Version:   version.Version,
+		Base:    p.pageCtx.Base(c, "Change Password", ""),
+		Message: "Your password has expired. Please choose a new password.",
 	}
+	context.User = session.User
 	return templates.Templates.ExecuteTemplate(c.Response(), localPasswordChangeTemplate, context)
 }
 

--- a/auth/provider_oauthbase.go
+++ b/auth/provider_oauthbase.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/foundriesio/update-server/server/ui/pagectx"
 	"github.com/foundriesio/update-server/server/ui/web/templates"
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/users"
@@ -45,7 +46,7 @@ func (p oauth2BaseProvider) Name() string {
 	return p.name
 }
 
-func (p *oauth2BaseProvider) configure(e *echo.Echo, usersStorage *users.Storage, cfg *storage.AuthConfig) error {
+func (p *oauth2BaseProvider) configure(e *echo.Echo, usersStorage *users.Storage, cfg *storage.AuthConfig, pageCtx PageContextBuilder) error {
 	if cfg.Type != p.Name() {
 		return fmt.Errorf("invalid config type for %s provider: %s", p.Name(), cfg.Type)
 	}
@@ -63,6 +64,7 @@ func (p *oauth2BaseProvider) configure(e *echo.Echo, usersStorage *users.Storage
 	p.users = usersStorage
 	p.rateLimiter = NewRateLimiter(cfg.RateLimits)
 	p.renderer = p
+	p.pageCtx = pageCtx
 	p.sessionTimeout = time.Duration(cfg.SessionTimeoutHours) * time.Hour
 
 	e.GET(AuthLoginPath, p.handleLogin, p.rateLimiter.Middleware)
@@ -77,24 +79,16 @@ func (p oauth2BaseProvider) renderLoginPage(c echo.Context, reason string) error
 			"error": "authentication required",
 		})
 	}
-	var csrfToken string
-	if cookie, err := c.Cookie(CsrfCookieName); err == nil {
-		csrfToken = cookie.Value
-	}
 	context := struct {
-		Title     string
-		LoginTip  string
-		Name      string
-		Reason    string
-		User      *users.User
-		NavItems  []string
-		CsrfToken string
+		pagectx.Base
+		LoginTip string
+		Name     string
+		Reason   string
 	}{
-		Title:     "Login",
-		LoginTip:  p.loginTip,
-		Name:      p.displayName,
-		Reason:    reason,
-		CsrfToken: csrfToken,
+		Base:     p.pageCtx.Base(c, "Login", ""),
+		LoginTip: p.loginTip,
+		Name:     p.displayName,
+		Reason:   reason,
 	}
 	return templates.Templates.ExecuteTemplate(c.Response(), "oauth2-login.html", context)
 }

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -200,7 +200,7 @@ func (testAuthProvider) Name() string {
 	return "test"
 }
 
-func (p testAuthProvider) Configure(e *echo.Echo, userS *users.Storage, config *storage.AuthConfig) error {
+func (p testAuthProvider) Configure(e *echo.Echo, userS *users.Storage, config *storage.AuthConfig, pageCtx auth.PageContextBuilder) error {
 	return nil
 }
 

--- a/server/ui/pagectx/pagectx.go
+++ b/server/ui/pagectx/pagectx.go
@@ -1,0 +1,28 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+// Package pagectx holds the shared "base" page context types used to render
+// HTML pages that extend base.html. It lives in a dependency-free leaf package
+// so both the web handlers and the auth providers can build the same base
+// context without creating an import cycle.
+package pagectx
+
+import "github.com/foundriesio/update-server/storage/users"
+
+// NavItem is a single entry in the top navigation bar.
+type NavItem struct {
+	Title    string
+	Href     string
+	Selected bool
+}
+
+// Base holds the fields every page that extends base.html needs.
+type Base struct {
+	User      *users.User
+	Title     string
+	BrandName string
+	LogoPath  string
+	NavItems  []NavItem
+	CsrfToken string
+	Version   string
+}

--- a/server/ui/server.go
+++ b/server/ui/server.go
@@ -37,24 +37,25 @@ func NewServer(ctx context.Context, db *storage.DbHandle, fs *storage.FsHandle, 
 	}
 	e := server.NewEchoServer()
 
-	provider, err := auth.NewProvider(e, db, fs, users)
-	if err != nil {
-		return nil, err
-	}
-	slog.Info("Using authentication provider", "name", provider.Name())
-
 	brandingData, err := fs.Config.ReadBrandingConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read branding config: %w", err)
 	}
 	branding := webHandlers.LoadBranding(brandingData)
+	pageBuilder := webHandlers.NewPageBuilder(branding)
+
+	provider, err := auth.NewProvider(e, db, fs, users, pageBuilder)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("Using authentication provider", "name", provider.Name())
 
 	daemons := daemons.New(ctx, strg, users)
 
 	srv := server.NewServer(ctx, e, serverName, bindAddr, nil)
 	e.Use(auth.CsrfCheck)
 	apiHandlers.RegisterHandlers(e, strg, provider)
-	webHandlers.RegisterHandlers(e, users, provider, branding, fs.Config.BrandingDir())
+	webHandlers.RegisterHandlers(e, users, provider, branding, fs.Config.BrandingDir(), pageBuilder)
 	return &apiServer{server: srv, daemons: daemons}, nil
 }
 

--- a/server/ui/web/handlers.go
+++ b/server/ui/web/handlers.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/foundriesio/update-server/auth"
 	"github.com/foundriesio/update-server/server"
+	"github.com/foundriesio/update-server/server/ui/pagectx"
 	"github.com/foundriesio/update-server/server/ui/web/templates"
 	"github.com/foundriesio/update-server/storage/users"
-	"github.com/foundriesio/update-server/version"
 )
 
 type handlers struct {
@@ -30,17 +30,19 @@ type handlers struct {
 	styleEtag   string
 	branding    Branding
 	brandingDir string
+	pages       PageBuilder
 }
 
 var EchoError = server.EchoError
 
-func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Provider, branding Branding, brandingDir string) {
+func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Provider, branding Branding, brandingDir string, pages PageBuilder) {
 	h := handlers{
 		users:       storage,
 		provider:    authProvider,
 		templates:   templates.Templates,
 		branding:    branding,
 		brandingDir: brandingDir,
+		pages:       pages,
 	}
 	var rendered bytes.Buffer
 	if err := h.templates.ExecuteTemplate(&rendered, "style.css", branding); err != nil {
@@ -95,34 +97,10 @@ func RegisterHandlers(e *echo.Echo, storage *users.Storage, authProvider auth.Pr
 	e.DELETE("/users/:username/tokens/:tokenID", h.userTokenDelete, h.requireSession)
 }
 
-type baseCtx struct {
-	User      *users.User
-	Title     string
-	BrandName string
-	LogoPath  string
-	NavItems  []navItem
-	CsrfToken string
-	Version   string
-}
+type baseCtx = pagectx.Base
 
 func (h handlers) baseCtx(c echo.Context, title, selected string) baseCtx {
-	var csrfToken string
-	if cookie, err := c.Cookie(auth.CsrfCookieName); err == nil {
-		csrfToken = cookie.Value
-	}
-	logoPath := ""
-	if h.branding.Logo != "" {
-		logoPath = "/branding/" + h.branding.Logo
-	}
-	return baseCtx{
-		User:      CtxGetSession(c.Request().Context()).User,
-		Title:     title,
-		BrandName: h.branding.Title,
-		LogoPath:  logoPath,
-		NavItems:  h.genNavItems(selected),
-		CsrfToken: csrfToken,
-		Version:   version.Version,
-	}
+	return h.pages.Base(c, title, selected)
 }
 
 func (h handlers) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
@@ -171,21 +149,7 @@ func (h handlers) favicon(c echo.Context) error {
 	return c.Blob(http.StatusOK, "image/svg+xml", b)
 }
 
-type navItem struct {
-	Title    string
-	Href     string
-	Selected bool
-}
-
-func (h handlers) genNavItems(selected string) []navItem {
-	navItems := []navItem{
-		{Title: "Devices", Href: "/devices", Selected: selected == "devices"},
-		{Title: "Configs", Href: "/configs", Selected: selected == "configs"},
-		{Title: "Updates", Href: "/updates", Selected: selected == "updates"},
-		{Title: "Users", Href: "/users", Selected: selected == "users"},
-	}
-	return navItems
-}
+type navItem = pagectx.NavItem
 
 func (h *handlers) authLogout(c echo.Context) error {
 	h.provider.DropSession(c, CtxGetSession(c.Request().Context()))

--- a/server/ui/web/pagebuilder.go
+++ b/server/ui/web/pagebuilder.go
@@ -1,0 +1,65 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package web
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/foundriesio/update-server/auth"
+	"github.com/foundriesio/update-server/server/ui/pagectx"
+	"github.com/foundriesio/update-server/storage/users"
+	"github.com/foundriesio/update-server/version"
+)
+
+// PageBuilder assembles the shared base.html page context (branding, nav,
+// version, current user, csrf). It is the single place base page context is
+// constructed, used by the web handlers as well as the auth providers' login
+// pages (via the auth.PageContextBuilder interface).
+type PageBuilder struct {
+	branding Branding
+}
+
+// NewPageBuilder returns a PageBuilder for the given branding.
+func NewPageBuilder(branding Branding) PageBuilder {
+	return PageBuilder{branding: branding}
+}
+
+// Base builds the base page context. It is safe to call when there is no
+// authenticated session (e.g. the login page): in that case User is nil and no
+// navigation items are included.
+func (b PageBuilder) Base(c echo.Context, title, selected string) pagectx.Base {
+	var csrfToken string
+	if cookie, err := c.Cookie(auth.CsrfCookieName); err == nil {
+		csrfToken = cookie.Value
+	}
+	logoPath := ""
+	if b.branding.Logo != "" {
+		logoPath = "/branding/" + b.branding.Logo
+	}
+	var user *users.User
+	var navItems []navItem
+	if session, ok := c.Request().Context().Value(ctxKeySession).(*auth.Session); ok && session != nil {
+		user = session.User
+		navItems = b.genNavItems(selected)
+	}
+	return pagectx.Base{
+		User:      user,
+		Title:     title,
+		BrandName: b.branding.Title,
+		LogoPath:  logoPath,
+		NavItems:  navItems,
+		CsrfToken: csrfToken,
+		Version:   version.Version,
+	}
+}
+
+func (b PageBuilder) genNavItems(selected string) []navItem {
+	navItems := []navItem{
+		{Title: "Devices", Href: "/devices", Selected: selected == "devices"},
+		{Title: "Configs", Href: "/configs", Selected: selected == "configs"},
+		{Title: "Updates", Href: "/updates", Selected: selected == "updates"},
+		{Title: "Users", Href: "/users", Selected: selected == "users"},
+	}
+	return navItems
+}


### PR DESCRIPTION
We've had this split where the auth package and UI package have their own logic for creating this base page context.

Every time we've added a new field, this time its branding stuff, we've broken some page's rendering logic. This change introduces logic to consolidate things and fights circular dependencies.

There are even better ways this could be done. However, this is the least invasive way and probably serves the size of our code well enough to survive with for the foreseeable future.