### PR TITLE
Add support for setting up user PKI from scratch

### DIFF
--- a/cmd/server/csr.go
+++ b/cmd/server/csr.go
@@ -4,11 +4,6 @@
 package main
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 
@@ -29,37 +24,15 @@ func (c CsrCmd) Run(args CommonArgs) error {
 		return err
 	}
 
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	priv, csrBytes, err := buildCsr(c.DnsName, c.Factory)
 	if err != nil {
-		return fmt.Errorf("unexpected error generating private key for CSR: %w", err)
+		return err
 	}
 
-	subj := pkix.Name{
-		CommonName:         c.DnsName,
-		OrganizationalUnit: []string{c.Factory},
-	}
-
-	template := x509.CertificateRequest{
-		Subject:            subj,
-		SignatureAlgorithm: x509.ECDSAWithSHA256,
-		DNSNames:           []string{c.DnsName},
-	}
-
-	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+	privPem, err := marshalKeyPem(priv)
 	if err != nil {
-		return fmt.Errorf("unexpected error creating CSR: %w", err)
+		return err
 	}
-
-	privDer, err := x509.MarshalECPrivateKey(priv)
-	if err != nil {
-		return fmt.Errorf("unexpected error encoding private key: %w", err)
-	}
-	privPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "EC PRIVATE KEY",
-			Bytes: privDer,
-		},
-	)
 	if err := fs.Certs.WriteFile(storage.CertsTlsKeyFile, privPem); err != nil {
 		return fmt.Errorf("unable to store TLS private key file: %w", err)
 	}

--- a/cmd/server/csr_sign.go
+++ b/cmd/server/csr_sign.go
@@ -5,14 +5,11 @@ package main
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"math/big"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/foundriesio/update-server/storage"
 )
@@ -48,35 +45,17 @@ func (c CsrSignCmd) Run(args CommonArgs) error {
 		return err
 	}
 
-	max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(160), nil)
-	serial, err := rand.Int(rand.Reader, max)
+	serial, err := newSerial()
 	if err != nil {
-		return fmt.Errorf("error generating certificate serial number: %w", err)
+		return err
 	}
 
-	crtTemplate := &x509.Certificate{
-		Subject:      csr.Subject,
-		Issuer:       caCrt.Subject,
-		SerialNumber: serial,
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(0, 0, c.ExpiryDays),
+	crtTemplate := tlsCertTemplate(csr, caCrt, serial, c.ExpiryDays)
 
-		IsCA:        false,
-		KeyUsage:    x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:    csr.DNSNames,
-	}
-
-	certDer, err := x509.CreateCertificate(rand.Reader, crtTemplate, caCrt, &tlsKey.PublicKey, caKey)
+	certPem, err := signCert(crtTemplate, caCrt, &tlsKey.PublicKey, caKey)
 	if err != nil {
 		return fmt.Errorf("error signing TLS cert: %w", err)
 	}
-	certPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: certDer,
-		},
-	)
 
 	if err := fs.Certs.WriteFile(storage.CertsTlsPemFile, certPem); err != nil {
 		return fmt.Errorf("unable to store TLS certificate: %w", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ type CommonArgs struct {
 	AuthInit *AuthInitCmd `arg:"subcommand:auth-init" help:"Initialize authentication configuration for this server"`
 	Csr      *CsrCmd      `arg:"subcommand:create-csr" help:"Create a TLS certificate signing request for this server"`
 	SignCsr  *CsrSignCmd  `arg:"subcommand:sign-csr" help:"Create the TLS certificate from the signing request"`
+	PkiInit  *PkiInitCmd  `arg:"subcommand:pki-init" help:"Bootstrap a complete PKI (root CA, TLS cert, and device CA) from scratch"`
 	Serve    *ServeCmd    `arg:"subcommand:serve" help:"Run the REST API and device-gateway services"`
 	TufInit  *TufInitCmd  `arg:"subcommand:tuf-init" help:"Initialize TUF keys and root metadata for this server"`
 	UserAdd  *UserAddCmd  `arg:"subcommand:user-add" help:"Add a new user if local authentication is enabled"`
@@ -47,6 +48,8 @@ func main() {
 		err = args.Csr.Run(args)
 	case args.SignCsr != nil:
 		err = args.SignCsr.Run(args)
+	case args.PkiInit != nil:
+		err = args.PkiInit.Run(args)
 	case args.Serve != nil:
 		err = args.Serve.Run(args)
 	case args.TufInit != nil:

--- a/cmd/server/pki.go
+++ b/cmd/server/pki.go
@@ -1,0 +1,105 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// generateEcKey creates a new EC P-256 private key.
+func generateEcKey() (*ecdsa.PrivateKey, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error generating private key: %w", err)
+	}
+	return priv, nil
+}
+
+// marshalKeyPem PEM-encodes an EC private key.
+func marshalKeyPem(key *ecdsa.PrivateKey) ([]byte, error) {
+	privDer, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error encoding private key: %w", err)
+	}
+	return pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privDer,
+		},
+	), nil
+}
+
+// newSerial generates a random 160-bit certificate serial number.
+func newSerial() (*big.Int, error) {
+	max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(160), nil)
+	serial, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return nil, fmt.Errorf("error generating certificate serial number: %w", err)
+	}
+	return serial, nil
+}
+
+// signCert creates a certificate from template, signed by parent using
+// parentKey for the given public key, and returns the PEM-encoded certificate.
+func signCert(template, parent *x509.Certificate, pub, parentKey any) ([]byte, error) {
+	certDer, err := x509.CreateCertificate(rand.Reader, template, parent, pub, parentKey)
+	if err != nil {
+		return nil, fmt.Errorf("error signing certificate: %w", err)
+	}
+	return pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certDer,
+		},
+	), nil
+}
+
+// tlsCertTemplate builds the x509 template for a server TLS certificate derived
+// from a CSR and issued by caCrt.
+func tlsCertTemplate(csr *x509.CertificateRequest, caCrt *x509.Certificate, serial *big.Int, expiryDays int) *x509.Certificate {
+	return &x509.Certificate{
+		Subject:      csr.Subject,
+		Issuer:       caCrt.Subject,
+		SerialNumber: serial,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(0, 0, expiryDays),
+
+		IsCA:        false,
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    csr.DNSNames,
+	}
+}
+
+// buildCsr generates a new EC key and a TLS certificate signing request for the
+// given DNS name and factory. It returns the key and the DER-encoded CSR bytes.
+func buildCsr(dnsName, factory string) (*ecdsa.PrivateKey, []byte, error) {
+	priv, err := generateEcKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         dnsName,
+			OrganizationalUnit: []string{factory},
+		},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		DNSNames:           []string{dnsName},
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected error creating CSR: %w", err)
+	}
+	return priv, csrBytes, nil
+}

--- a/cmd/server/pki_init.go
+++ b/cmd/server/pki_init.go
@@ -1,0 +1,152 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/foundriesio/update-server/storage"
+)
+
+type PkiInitCmd struct {
+	DnsName       string `arg:"required" help:"DNS host name devices address this gateway with"`
+	Factory       string `arg:"required"`
+	TlsExpiryDays int    `default:"365" help:"TLS certificate validity in days"`
+	CaExpiryDays  int    `default:"7300" help:"Root and device CA certificate validity in days"`
+}
+
+func (c PkiInitCmd) Run(args CommonArgs) error {
+	fs, err := storage.NewFs(args.DataDir)
+	if err != nil {
+		return err
+	}
+	if err = fs.Certs.AssertCleanPki(); err != nil {
+		return err
+	}
+
+	// 1. Root CA
+	rootKey, err := generateEcKey()
+	if err != nil {
+		return err
+	}
+	serial, err := newSerial()
+	if err != nil {
+		return err
+	}
+	rootTemplate := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         c.Factory + "-root",
+			OrganizationalUnit: []string{c.Factory},
+		},
+		SerialNumber:          serial,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, c.CaExpiryDays),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	rootPem, err := signCert(rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return fmt.Errorf("error creating root CA: %w", err)
+	}
+	// signCert produced a self-signed cert; parse it back so it can be used
+	// to issue child certificates.
+	rootBlock, _ := pem.Decode(rootPem)
+	if rootBlock == nil {
+		return fmt.Errorf("unexpected error decoding root CA PEM")
+	}
+	rootCrt, err := x509.ParseCertificate(rootBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("error parsing root CA: %w", err)
+	}
+	rootKeyPem, err := marshalKeyPem(rootKey)
+	if err != nil {
+		return err
+	}
+	if err := fs.Certs.WriteFile(storage.CertsRootKeyFile, rootKeyPem); err != nil {
+		return fmt.Errorf("unable to store root CA key: %w", err)
+	}
+	if err := fs.Certs.WriteFile(storage.CertsRootPemFile, rootPem); err != nil {
+		return fmt.Errorf("unable to store root CA cert: %w", err)
+	}
+
+	// 2. TLS keypair signed by the root CA (reusing the create-csr/sign-csr path)
+	tlsKey, csrBytes, err := buildCsr(c.DnsName, c.Factory)
+	if err != nil {
+		return err
+	}
+	csr, err := x509.ParseCertificateRequest(csrBytes)
+	if err != nil {
+		return fmt.Errorf("error parsing generated CSR: %w", err)
+	}
+	tlsSerial, err := newSerial()
+	if err != nil {
+		return err
+	}
+	tlsTemplate := tlsCertTemplate(csr, rootCrt, tlsSerial, c.TlsExpiryDays)
+	tlsPem, err := signCert(tlsTemplate, rootCrt, &tlsKey.PublicKey, rootKey)
+	if err != nil {
+		return fmt.Errorf("error signing TLS cert: %w", err)
+	}
+	tlsKeyPem, err := marshalKeyPem(tlsKey)
+	if err != nil {
+		return err
+	}
+	if err := fs.Certs.WriteFile(storage.CertsTlsKeyFile, tlsKeyPem); err != nil {
+		return fmt.Errorf("unable to store TLS key: %w", err)
+	}
+	if err := fs.Certs.WriteFile(storage.CertsTlsPemFile, tlsPem); err != nil {
+		return fmt.Errorf("unable to store TLS cert: %w", err)
+	}
+
+	// 3. Device signing CA signed by the root CA
+	deviceKey, err := generateEcKey()
+	if err != nil {
+		return err
+	}
+	deviceSerial, err := newSerial()
+	if err != nil {
+		return err
+	}
+	deviceTemplate := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         c.Factory + "-device-ca",
+			OrganizationalUnit: []string{c.Factory},
+		},
+		Issuer:                rootCrt.Subject,
+		SerialNumber:          deviceSerial,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, c.CaExpiryDays),
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	devicePem, err := signCert(deviceTemplate, rootCrt, &deviceKey.PublicKey, rootKey)
+	if err != nil {
+		return fmt.Errorf("error signing device CA: %w", err)
+	}
+	deviceKeyPem, err := marshalKeyPem(deviceKey)
+	if err != nil {
+		return err
+	}
+	if err := fs.Certs.WriteFile(storage.CertsDeviceCaKeyFile, deviceKeyPem); err != nil {
+		return fmt.Errorf("unable to store device CA key: %w", err)
+	}
+	if err := fs.Certs.WriteFile(storage.CertsDeviceCaPemFile, devicePem); err != nil {
+		return fmt.Errorf("unable to store device CA cert: %w", err)
+	}
+
+	// 4. Trust the device CA for device mTLS
+	if err := fs.Certs.WriteFile(storage.CertsCasPemFile, devicePem); err != nil {
+		return fmt.Errorf("unable to store cas.pem: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/server/pki_init_test.go
+++ b/cmd/server/pki_init_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"crypto/x509"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/foundriesio/update-server/storage"
+)
+
+func TestPkiInit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cmd := PkiInitCmd{
+		DnsName:       "example.com",
+		Factory:       "example",
+		TlsExpiryDays: 365,
+		CaExpiryDays:  3650,
+	}
+	common := CommonArgs{DataDir: tmpDir}
+	require.Nil(t, cmd.Run(common))
+
+	fs, err := storage.NewFs(common.DataDir)
+	require.Nil(t, err)
+
+	// All expected files exist.
+	for _, name := range []string{
+		storage.CertsRootKeyFile, storage.CertsRootPemFile,
+		storage.CertsTlsKeyFile, storage.CertsTlsPemFile,
+		storage.CertsDeviceCaKeyFile, storage.CertsDeviceCaPemFile,
+		storage.CertsCasPemFile,
+	} {
+		_, err := os.Stat(fs.Certs.FilePath(name))
+		require.Nil(t, err, "missing file %s", name)
+	}
+
+	rootCrt, err := loadCert(fs.Certs.FilePath(storage.CertsRootPemFile))
+	require.Nil(t, err)
+	require.True(t, rootCrt.IsCA)
+	require.Equal(t, []string{"example"}, rootCrt.Subject.OrganizationalUnit)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCrt)
+
+	// TLS cert chains to the root and carries the expected subject.
+	tlsCrt, err := loadCert(fs.Certs.FilePath(storage.CertsTlsPemFile))
+	require.Nil(t, err)
+	require.Equal(t, "example.com", tlsCrt.Subject.CommonName)
+	require.Equal(t, []string{"example"}, tlsCrt.Subject.OrganizationalUnit)
+	require.False(t, tlsCrt.IsCA)
+	_, err = tlsCrt.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSName:   "example.com",
+	})
+	require.Nil(t, err)
+
+	// Device CA is a CA that chains to the root.
+	deviceCrt, err := loadCert(fs.Certs.FilePath(storage.CertsDeviceCaPemFile))
+	require.Nil(t, err)
+	require.True(t, deviceCrt.IsCA)
+	_, err = deviceCrt.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	require.Nil(t, err)
+
+	// cas.pem is the device CA.
+	casBytes, err := fs.Certs.ReadFile(storage.CertsCasPemFile)
+	require.Nil(t, err)
+	deviceBytes, err := fs.Certs.ReadFile(storage.CertsDeviceCaPemFile)
+	require.Nil(t, err)
+	require.Equal(t, deviceBytes, casBytes)
+
+	// Re-running refuses to overwrite the existing PKI.
+	err = cmd.Run(common)
+	require.NotNil(t, err)
+	require.True(t, errors.Is(err, os.ErrExist))
+}

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,7 +16,38 @@ For Linux and Mac, make sure to `chmod +x fioserver`.
 
 ## Configure Mutual TLS
 
-### Creat Certificate Signing requests for TLS
+There are two ways to set up the mutual TLS certificates which are used by 
+devices to authenticate with this server:
+
+* **Bootstrap a new PKI from scratch** with `pki-init` — use this if you do
+  not already have a FoundriesFactory PKI (see below).
+* **Sign a CSR with an existing factory PKI** using `create-csr` and
+  `sign-csr` — use this if you already have a factory root key and device
+  CAs (see [Sign with an existing factory PKI](#sign-with-an-existing-factory-pki)).
+
+### Bootstrap a new PKI from scratch
+
+If you don't have a pre-existing factory PKI, `pki-init` creates everything
+in one step:
+
+```
+  ./fioserver --datadir=./datadir pki-init --dnsname <HOSTNAME> --factory <FACTORY>
+```
+
+This generates, under `datadir/certs`:
+
+* a self-signed root CA (`root.key`/`root.crt`) with `OU=<FACTORY>`,
+* the server TLS keypair signed by the root CA (`tls.key`/`tls.pem`),
+* an intermediate device-signing CA (`device-ca.key`/`device-ca.crt`), and
+* `cas.pem`, containing the device CA so devices can authenticate.
+
+Import `root.crt` into your devices' trust store so they trust the server's
+TLS certificate. You can then skip ahead to
+[Configure User Authentication](#configure-user-authentication).
+
+### Sign with an existing factory PKI
+
+#### Creat Certificate Signing requests for TLS
 
 Devices need to trust the TLS connection they make to this server. In
 order to do this, you must create a CSR to be signed with the Factory
@@ -26,7 +57,7 @@ root key:
   ./fioserver --datadir=./datadir create-csr --dnsname <HOSTNAME> --factory <FACTORY>
 ```
 
-### Sign the Request
+#### Sign the Request
 
 Copy `datadir/certs/tls.csr` to the computer with your factory PKI. This
 file does not contain sensitive information, so it is safe to share as
@@ -40,7 +71,7 @@ This command will print the contents of the certificate. The contents are
 not sensitive. Go back to the update server system and create the
 file `datadir/certs/tls.pem` with this content.
 
-### Grant Access to Devices
+#### Grant Access to Devices
 
 This service needs to know what devices can connect to it. You can allow
 all valid factory devices to connect with:

--- a/storage/file.go
+++ b/storage/file.go
@@ -37,6 +37,11 @@ const (
 	CertsTlsKeyFile = "tls.key"
 	CertsTlsPemFile = "tls.pem"
 
+	CertsRootKeyFile     = "root.key"
+	CertsRootPemFile     = "root.crt"
+	CertsDeviceCaKeyFile = "device-ca.key"
+	CertsDeviceCaPemFile = "device-ca.crt"
+
 	AuthConfigFile     = "auth-config.json"
 	BrandingConfigFile = "branding.json"
 	HmacFile           = "hmac.secret"

--- a/storage/file_certs.go
+++ b/storage/file_certs.go
@@ -39,13 +39,26 @@ func (s CertsFsHandle) WriteFile(name string, content []byte) error {
 }
 
 func (s CertsFsHandle) AssertCleanTls() error {
-	for _, name := range []string{
+	return s.assertClean([]string{
 		CertsTlsCsrFile, CertsTlsKeyFile, CertsTlsPemFile,
-	} {
+	})
+}
+
+func (s CertsFsHandle) AssertCleanPki() error {
+	return s.assertClean([]string{
+		CertsTlsCsrFile, CertsTlsKeyFile, CertsTlsPemFile,
+		CertsRootKeyFile, CertsRootPemFile,
+		CertsDeviceCaKeyFile, CertsDeviceCaPemFile,
+		CertsCasPemFile,
+	})
+}
+
+func (s CertsFsHandle) assertClean(names []string) error {
+	for _, name := range names {
 		if _, err := os.Stat(filepath.Join(s.root, name)); err == nil {
-			return fmt.Errorf("a TLS file %s already exists: %w", name, os.ErrExist)
+			return fmt.Errorf("a certificate file %s already exists: %w", name, os.ErrExist)
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("failed to check if a TLS file %s exists: %w", name, err)
+			return fmt.Errorf("failed to check if a certificate file %s exists: %w", name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This feature helps users w/o the intial PKI created from the FoundriesFactory product

Fixes #173 