### PR TITLE
Add support for lmp-device-register

### DIFF
--- a/auth/csrf.go
+++ b/auth/csrf.go
@@ -42,7 +42,7 @@ func CsrfCheck(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		// Skip CSRF check for token-authenticated API requests
-		if c.Request().Header.Get("Authorization") != "" {
+		if c.Request().Header.Get("Authorization") != "" || c.Request().Header.Get("OSF-TOKEN") != "" {
 			return next(c)
 		}
 

--- a/auth/provider_common.go
+++ b/auth/provider_common.go
@@ -38,15 +38,22 @@ func (p *commonProvider) DropSession(c echo.Context, session *Session) {
 
 func (p *commonProvider) GetUser(c echo.Context) (*users.User, error) {
 	authHeader := c.Request().Header.Get("Authorization")
-	if len(authHeader) > 0 {
+	authToken := ""
+	if len(authHeader) == 0 {
+		authToken = c.Request().Header.Get("OSF-TOKEN")
+	}
+	if len(authHeader) > 0 || len(authToken) > 0 {
 		if err := p.rateLimiter.allow(c.RealIP()); err != nil {
 			return nil, server.EchoError(c, err, http.StatusTooManyRequests, err.Error())
 		}
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
-			return nil, fmt.Errorf("invalid authorization header")
+		if len(authHeader) > 0 {
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+				return nil, fmt.Errorf("invalid authorization header")
+			}
+			authToken = parts[1]
 		}
-		user, err := p.users.GetByToken(parts[1])
+		user, err := p.users.GetByToken(authToken)
 		if err != nil {
 			p.rateLimiter.FlagBadOperation(c)
 			slog.Warn("unable to get user by token", "error", err)

--- a/cmd/server/csr_sign.go
+++ b/cmd/server/csr_sign.go
@@ -4,12 +4,8 @@
 package main
 
 import (
-	"crypto/ecdsa"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/foundriesio/update-server/storage"
 )
@@ -26,21 +22,21 @@ func (c CsrSignCmd) Run(args CommonArgs) error {
 		return err
 	}
 
-	caCrt, err := loadCert(c.CaCert)
+	caCrt, err := storage.LoadPemFile(c.CaCert, x509.ParseCertificate)
 	if err != nil {
 		return err
 	}
 
-	caKey, err := loadKey(c.CaKey)
+	caKey, err := storage.LoadPemFile(c.CaKey, x509.ParseECPrivateKey)
 	if err != nil {
 		return err
 	}
 
-	csr, err := loadCsr(fs.Certs.FilePath(storage.CertsTlsCsrFile))
+	csr, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsTlsCsrFile), x509.ParseCertificateRequest)
 	if err != nil {
 		return err
 	}
-	tlsKey, err := loadKey(fs.Certs.FilePath(storage.CertsTlsKeyFile))
+	tlsKey, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsTlsKeyFile), x509.ParseECPrivateKey)
 	if err != nil {
 		return err
 	}
@@ -62,46 +58,4 @@ func (c CsrSignCmd) Run(args CommonArgs) error {
 	}
 
 	return nil
-}
-
-func loadCert(path string) (*x509.Certificate, error) {
-	cert, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read cert: %w", err)
-	}
-
-	first, rest := pem.Decode(cert)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", path)
-	}
-
-	return x509.ParseCertificate(first.Bytes)
-}
-
-func loadCsr(path string) (*x509.CertificateRequest, error) {
-	csr, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read csr: %w", err)
-	}
-
-	first, rest := pem.Decode(csr)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", path)
-	}
-
-	return x509.ParseCertificateRequest(first.Bytes)
-}
-
-func loadKey(path string) (*ecdsa.PrivateKey, error) {
-	key, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read pkey: %w", err)
-	}
-
-	first, rest := pem.Decode(key)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", path)
-	}
-
-	return x509.ParseECPrivateKey(first.Bytes)
 }

--- a/cmd/server/csr_test.go
+++ b/cmd/server/csr_test.go
@@ -43,7 +43,7 @@ func TestCsr(t *testing.T) {
 	}
 	require.Nil(t, sign.Run(common))
 
-	cert, err := loadCert(fs.Certs.FilePath(storage.CertsTlsPemFile))
+	cert, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsTlsPemFile), x509.ParseCertificate)
 	require.Nil(t, err)
 	require.Equal(t, "example.com", cert.Subject.CommonName)
 
@@ -55,7 +55,7 @@ func TestCsr(t *testing.T) {
 
 func createSelfSignedRoot(t *testing.T, fs *storage.FsHandle) (string, string) {
 	caKeyFile := fs.Certs.FilePath(storage.CertsTlsKeyFile) // reuse the key we already generated
-	key, err := loadKey(caKeyFile)
+	key, err := storage.LoadPemFile(caKeyFile, x509.ParseECPrivateKey)
 	require.Nil(t, err)
 
 	ca := &x509.Certificate{

--- a/cmd/server/pki_init.go
+++ b/cmd/server/pki_init.go
@@ -6,7 +6,6 @@ package main
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -56,11 +55,7 @@ func (c PkiInitCmd) Run(args CommonArgs) error {
 	}
 	// signCert produced a self-signed cert; parse it back so it can be used
 	// to issue child certificates.
-	rootBlock, _ := pem.Decode(rootPem)
-	if rootBlock == nil {
-		return fmt.Errorf("unexpected error decoding root CA PEM")
-	}
-	rootCrt, err := x509.ParseCertificate(rootBlock.Bytes)
+	rootCrt, err := storage.PemBytesToObject(rootPem, x509.ParseCertificate)
 	if err != nil {
 		return fmt.Errorf("error parsing root CA: %w", err)
 	}

--- a/cmd/server/pki_init_test.go
+++ b/cmd/server/pki_init_test.go
@@ -40,7 +40,7 @@ func TestPkiInit(t *testing.T) {
 		require.Nil(t, err, "missing file %s", name)
 	}
 
-	rootCrt, err := loadCert(fs.Certs.FilePath(storage.CertsRootPemFile))
+	rootCrt, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsRootPemFile), x509.ParseCertificate)
 	require.Nil(t, err)
 	require.True(t, rootCrt.IsCA)
 	require.Equal(t, []string{"example"}, rootCrt.Subject.OrganizationalUnit)
@@ -49,7 +49,7 @@ func TestPkiInit(t *testing.T) {
 	roots.AddCert(rootCrt)
 
 	// TLS cert chains to the root and carries the expected subject.
-	tlsCrt, err := loadCert(fs.Certs.FilePath(storage.CertsTlsPemFile))
+	tlsCrt, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsTlsPemFile), x509.ParseCertificate)
 	require.Nil(t, err)
 	require.Equal(t, "example.com", tlsCrt.Subject.CommonName)
 	require.Equal(t, []string{"example"}, tlsCrt.Subject.OrganizationalUnit)
@@ -62,7 +62,7 @@ func TestPkiInit(t *testing.T) {
 	require.Nil(t, err)
 
 	// Device CA is a CA that chains to the root.
-	deviceCrt, err := loadCert(fs.Certs.FilePath(storage.CertsDeviceCaPemFile))
+	deviceCrt, err := storage.LoadPemFile(fs.Certs.FilePath(storage.CertsDeviceCaPemFile), x509.ParseCertificate)
 	require.Nil(t, err)
 	require.True(t, deviceCrt.IsCA)
 	_, err = deviceCrt.Verify(x509.VerifyOptions{

--- a/contrib/auth-config-github.json
+++ b/contrib/auth-config-github.json
@@ -2,6 +2,7 @@
   "Type": "github",
   "SessionTimeoutHours": 48,
   "NewUserDefaultScopes": [
+    "devices:create",
     "devices:delete",
     "devices:read",
     "devices:read-update",

--- a/contrib/auth-config-google.json
+++ b/contrib/auth-config-google.json
@@ -2,6 +2,7 @@
   "Type": "google",
   "SessionTimeoutHours": 48,
   "NewUserDefaultScopes": [
+    "devices:create",
     "devices:delete",
     "devices:read",
     "devices:read-update",

--- a/contrib/auth-config-local.json
+++ b/contrib/auth-config-local.json
@@ -13,6 +13,7 @@
     }
   },
   "NewUserDefaultScopes": [
+    "devices:create",
     "devices:delete",
     "devices:read",
     "devices:read-update",

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -6,6 +6,7 @@ package api
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
 
 	"github.com/foundriesio/update-server/auth"
 	"github.com/foundriesio/update-server/server"
@@ -14,13 +15,18 @@ import (
 )
 
 type handlers struct {
+	ca      *DeviceCa
 	storage *storage.Storage
 }
 
 var EchoError = server.EchoError
 
-func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
-	h := handlers{storage: storage}
+func RegisterHandlers(e *echo.Echo, ca *DeviceCa, storage *storage.Storage, a auth.Provider) {
+	h := handlers{
+		ca:      ca,
+		storage: storage,
+	}
+
 	g := e.Group("/v1")
 	g.Use(authUser(a))
 
@@ -37,6 +43,11 @@ func RegisterHandlers(e *echo.Echo, storage *storage.Storage, a auth.Provider) {
 	g.GET("/configs/device/:uuid/applied", h.deviceAppliedConfigsGet, requireScope(users.ScopeDevicesR))
 	g.GET("/configs/device/:uuid/history", h.deviceConfigsHistory, requireScope(users.ScopeDevicesR))
 	g.GET("/devices", h.deviceList, requireScope(users.ScopeDevicesR))
+	if ca != nil {
+		// Limit this API to 2 devices per-second
+		rl := middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(2)))
+		g.POST("/devices", h.deviceCreate, requireScope(users.ScopeDevicesC), rl)
+	}
 	g.GET("/devices/:uuid", h.deviceGet, requireScope(users.ScopeDevicesR))
 	g.DELETE("/devices/:uuid", h.deviceDelete, requireScope(users.ScopeDevicesD))
 	g.GET("/denied-devices", h.deniedDevicesList, requireScope(users.ScopeDevicesR))

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/foundriesio/update-server/storage"
@@ -39,12 +38,7 @@ func LoadDeviceCa(fs *storage.FsHandle) (*DeviceCa, error) {
 		}
 		return nil, err
 	}
-	first, rest := pem.Decode(buf)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsDeviceCaKeyFile)
-	}
-
-	key, err := x509.ParseECPrivateKey(first.Bytes)
+	key, err := storage.PemBytesToObject(buf, x509.ParseECPrivateKey)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +50,7 @@ func LoadDeviceCa(fs *storage.FsHandle) (*DeviceCa, error) {
 		}
 		return nil, err
 	}
-	first, rest = pem.Decode(buf)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsDeviceCaPemFile)
-	}
-
-	cert, err := x509.ParseCertificate(first.Bytes)
+	cert, err := storage.PemBytesToObject(buf, x509.ParseCertificate)
 	if err != nil {
 		return nil, err
 	}
@@ -81,12 +70,7 @@ func LoadDeviceCa(fs *storage.FsHandle) (*DeviceCa, error) {
 	if err != nil {
 		return nil, err
 	}
-	first, rest = pem.Decode(buf)
-	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
-		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsTlsPemFile)
-	}
-
-	tlsCert, err := x509.ParseCertificate(first.Bytes)
+	tlsCert, err := storage.PemBytesToObject(buf, x509.ParseCertificate)
 	if err != nil {
 		return nil, err
 	}

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -4,15 +4,18 @@
 package api
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -162,9 +165,12 @@ func (h handlers) deviceCreate(c echo.Context) error {
 		return EchoError(c, err, http.StatusBadRequest, err.Error())
 	}
 
+	sotaBytes := genSotaToml(req, h.ca.DgUrl)
+
 	resp := DeviceCreateResponse{
 		RootCrt:   h.ca.RootCert,
 		ClientPem: string(cert),
+		SotaToml:  string(sotaBytes),
 	}
 	return c.JSON(http.StatusCreated, resp)
 }
@@ -191,4 +197,66 @@ func genCert(uuid, csr string, ca *DeviceCa) ([]byte, *x509.CertificateRequest, 
 
 	cert, err := ca.SignCsr(req)
 	return cert, req, err
+}
+
+func genSotaToml(req DeviceCreateRequest, urlBase string) []byte {
+	if len(req.SotaConfigDir) == 0 {
+		req.SotaConfigDir = "/var/sota"
+	}
+
+	sota := SotaToml{
+		"tls": {
+			"server":      urlBase,
+			"ca_source":   "file",
+			"pkey_source": "file",
+			"cert_source": "file",
+		},
+		"provision": {
+			"server":                  urlBase,
+			"primary_ecu_hardware_id": req.HardwareId,
+		},
+		"uptane": {
+			"repo_server": urlBase + "/repo",
+			"key_source":  "file",
+		},
+		"pacman": {
+			"type":               "ostree",
+			"compose_apps_proxy": urlBase + "/app-proxy-url",
+			"ostree_server":      urlBase + "/ostree",
+			"packages_file":      "/usr/package.manifest",
+		},
+		"storage": {
+			"type": "sqlite",
+			"path": req.SotaConfigDir,
+		},
+		"import": {
+			"tls_cacert_path":     filepath.Join(req.SotaConfigDir, "root.crt"),
+			"tls_pkey_path":       filepath.Join(req.SotaConfigDir, "pkey.pem"),
+			"tls_clientcert_path": filepath.Join(req.SotaConfigDir, "client.pem"),
+		},
+	}
+
+	// merge overrides
+	for section, kv := range req.Overrides {
+		if _, ok := sota[section]; !ok {
+			sota[section] = map[string]string{}
+		}
+		maps.Copy(sota[section], kv)
+	}
+
+	var buf bytes.Buffer
+	for section, kv := range sota {
+		fmt.Fprintf(&buf, "[%s]\n", section)
+		for k, v := range kv {
+			if len(v) == 0 {
+				fmt.Fprintf(&buf, "# %s disabled\n", k)
+			} else if v[0] == '"' {
+				fmt.Fprintf(&buf, "%s = %s\n", k, v)
+			} else {
+				fmt.Fprintf(&buf, "%s = \"%s\"\n", k, v)
+			}
+		}
+		fmt.Fprintln(&buf)
+	}
+	return buf.Bytes()
 }

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -160,12 +160,42 @@ func (h handlers) deviceCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "Uuid is required")
 	}
 
-	cert, _, err := genCert(req.Uuid, req.Csr, h.ca)
+	cert, csr, err := genCert(req.Uuid, req.Csr, h.ca)
 	if err != nil {
 		return EchoError(c, err, http.StatusBadRequest, err.Error())
 	}
 
+	labels := map[string]string{}
+	if len(req.Name) > 0 {
+		labels["name"] = req.Name
+		if !validateLabelValue(req.Name) {
+			return EchoError(c, fmt.Errorf("invalid name label value: %s", req.Name), http.StatusBadRequest, "Invalid name label value")
+		}
+	}
+	if len(req.Group) > 0 {
+		labels["group"] = req.Group
+		groups, err := h.storage.GetKnownDeviceGroupNames()
+		if err != nil {
+			return EchoError(c, err, http.StatusInternalServerError, err.Error())
+		}
+		if !slices.Contains(groups, req.Group) {
+			return EchoError(c, fmt.Errorf("invalid group: %s", req.Group), http.StatusBadRequest, "Invalid group")
+		}
+	}
+
+	pubkey, err := pubkey(csr)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to extract public key from CSR")
+	}
+
 	sotaBytes := genSotaToml(req, h.ca.DgUrl)
+
+	if err := h.storage.DeviceCreate(req.Uuid, pubkey, labels); err != nil {
+		if storage.IsDbError(err, storage.ErrDbConstraintUnique) {
+			return EchoError(c, err, http.StatusConflict, "Device already exists")
+		}
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to create device")
+	}
 
 	resp := DeviceCreateResponse{
 		RootCrt:   h.ca.RootCert,
@@ -197,6 +227,18 @@ func genCert(uuid, csr string, ca *DeviceCa) ([]byte, *x509.CertificateRequest, 
 
 	cert, err := ca.SignCsr(req)
 	return cert, req, err
+}
+
+func pubkey(csr *x509.CertificateRequest) (string, error) {
+	derBytes, err := x509.MarshalPKIXPublicKey(csr.PublicKey)
+	if err != nil {
+		return "", err
+	}
+	block := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}
+	return string(pem.EncodeToMemory(block)), nil
 }
 
 func genSotaToml(req DeviceCreateRequest, urlBase string) []byte {

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -5,13 +5,17 @@ package api
 
 import (
 	"crypto"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/foundriesio/update-server/storage"
 	"github.com/labstack/echo/v4"
@@ -92,6 +96,33 @@ func LoadDeviceCa(fs *storage.FsHandle) (*DeviceCa, error) {
 	}, nil
 }
 
+func (ca DeviceCa) SignCsr(csr *x509.CertificateRequest) ([]byte, error) {
+	if !slices.Equal(ca.CaCert.Subject.OrganizationalUnit, csr.Subject.OrganizationalUnit) {
+		return nil, fmt.Errorf("CSR OU %v does not match CA OU %v", csr.Subject.OrganizationalUnit, ca.CaCert.Subject.OrganizationalUnit)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               csr.Subject,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(7300 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, ca.CaCert, csr.PublicKey, ca.CaKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes}), nil
+}
+
 type SotaToml map[string]map[string]string
 
 type DeviceCreateRequest struct {
@@ -126,5 +157,38 @@ func (h handlers) deviceCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, "Uuid is required")
 	}
 
-	return nil
+	cert, _, err := genCert(req.Uuid, req.Csr, h.ca)
+	if err != nil {
+		return EchoError(c, err, http.StatusBadRequest, err.Error())
+	}
+
+	resp := DeviceCreateResponse{
+		RootCrt:   h.ca.RootCert,
+		ClientPem: string(cert),
+	}
+	return c.JSON(http.StatusCreated, resp)
+}
+
+func genCert(uuid, csr string, ca *DeviceCa) ([]byte, *x509.CertificateRequest, error) {
+	block, _ := pem.Decode([]byte(csr))
+	if block == nil {
+		return nil, nil, fmt.Errorf("invalid CSR PEM encoding")
+	}
+	if block.Type != "CERTIFICATE REQUEST" {
+		return nil, nil, fmt.Errorf("invalid CSR PEM encoding: %s", block.Type)
+	}
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid CSR: %w", err)
+	}
+	if err := req.CheckSignature(); err != nil {
+		return nil, nil, fmt.Errorf("CSR signature verification failed: %w", err)
+	}
+
+	if uuid != req.Subject.CommonName {
+		return nil, nil, fmt.Errorf("CSR CommonName must match the requested UUID: %s != %s", req.Subject.CommonName, uuid)
+	}
+
+	cert, err := ca.SignCsr(req)
+	return cert, req, err
 }

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -1,0 +1,130 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package api
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/foundriesio/update-server/storage"
+	"github.com/labstack/echo/v4"
+)
+
+type DeviceCa struct {
+	CaCert   *x509.Certificate
+	CaKey    crypto.Signer
+	RootCert string
+	DgUrl    string
+}
+
+func LoadDeviceCa(fs *storage.FsHandle) (*DeviceCa, error) {
+	buf, err := fs.Certs.ReadFile(storage.CertsDeviceCaKeyFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	first, rest := pem.Decode(buf)
+	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
+		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsDeviceCaKeyFile)
+	}
+
+	key, err := x509.ParseECPrivateKey(first.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err = fs.Certs.ReadFile(storage.CertsDeviceCaPemFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	first, rest = pem.Decode(buf)
+	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
+		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsDeviceCaPemFile)
+	}
+
+	cert, err := x509.ParseCertificate(first.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if !cert.IsCA {
+		return nil, fmt.Errorf("certificate in %s is not a CA certificate", storage.CertsDeviceCaPemFile)
+	}
+
+	buf, err = fs.Certs.ReadFile(storage.CertsRootPemFile)
+	if err != nil {
+		return nil, err
+	}
+	rootCrt := string(buf)
+
+	// load dg tls cert to get the DG URL
+	buf, err = fs.Certs.ReadFile(storage.CertsTlsPemFile)
+	if err != nil {
+		return nil, err
+	}
+	first, rest = pem.Decode(buf)
+	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
+		return nil, fmt.Errorf("malformed PEM data for %s", storage.CertsTlsPemFile)
+	}
+
+	tlsCert, err := x509.ParseCertificate(first.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeviceCa{
+		CaCert:   cert,
+		CaKey:    key,
+		RootCert: rootCrt,
+		DgUrl:    "https://" + tlsCert.DNSNames[0] + ":8443",
+	}, nil
+}
+
+type SotaToml map[string]map[string]string
+
+type DeviceCreateRequest struct {
+	Uuid          string   `json:"uuid"`
+	Name          string   `json:"name"` // todo validate pattern and length
+	Group         string   `json:"group"`
+	HardwareId    string   `json:"hardware-id"`
+	Csr           string   `json:"csr"`
+	SotaConfigDir string   `json:"sota-config-dir"`
+	Overrides     SotaToml `json:"overrides"`
+}
+
+type DeviceCreateResponse struct {
+	RootCrt   string `json:"root.crt"`
+	ClientPem string `json:"client.pem"`
+	SotaToml  string `json:"sota.toml"`
+}
+
+// @Summary Create device. Used by lmp-device-register compliant tooling
+// @Accept  json
+// @Produce json
+// @Param data body DeviceCreateRequest true "Device creation request"
+// @Success 201 {object} DeviceCreateResponse
+// @Router  /devices/ [post]
+func (h handlers) deviceCreate(c echo.Context) error {
+	var req DeviceCreateRequest
+	if err := c.Bind(&req); err != nil {
+		return EchoError(c, err, http.StatusBadRequest, "Bad JSON body")
+	}
+
+	if len(req.Uuid) == 0 {
+		return c.JSON(http.StatusBadRequest, "Uuid is required")
+	}
+
+	return nil
+}

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -237,7 +237,7 @@ func NewTestClient(t *testing.T) *testClient {
 		Username:      "root",
 		AllowedScopes: 0,
 	}
-	RegisterHandlers(e, apiS, &testAuthProvider{user: u})
+	RegisterHandlers(e, nil, apiS, &testAuthProvider{user: u})
 
 	tc := testClient{
 		t:   t,

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -6,9 +6,16 @@ package api
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -216,6 +223,10 @@ func (testAuthProvider) DropSession(echo.Context, *auth.Session) {
 }
 
 func NewTestClient(t *testing.T) *testClient {
+	return NewTestClientWithCA(t, "")
+}
+
+func NewTestClientWithCA(t *testing.T, org string) *testClient {
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 	fsS, err := apiStorage.NewFs(tmpDir)
@@ -227,6 +238,61 @@ func NewTestClient(t *testing.T) *testClient {
 	gwS, err := gatewayStorage.NewStorage(db, fsS)
 	require.Nil(t, err)
 
+	var deviceCa *DeviceCa
+	if len(org) > 0 {
+		caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.Nil(t, err)
+		caKeyDer, err := x509.MarshalECPrivateKey(caKey)
+		require.Nil(t, err)
+		caKeyPem := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: caKeyDer})
+
+		caTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName:         "test-ca",
+				OrganizationalUnit: []string{"test-ou"},
+			},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		caCertDer, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+		require.Nil(t, err)
+		caCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDer})
+		caCert, err := x509.ParseCertificate(caCertDer)
+		require.Nil(t, err)
+
+		require.Nil(t, fsS.Certs.WriteFile(storage.CertsDeviceCaKeyFile, caKeyPem))
+		require.Nil(t, fsS.Certs.WriteFile(storage.CertsDeviceCaPemFile, caCertPem))
+		require.Nil(t, fsS.Certs.WriteFile(storage.CertsRootPemFile, caCertPem)) // doesn't matter for tests, just needs to exist
+
+		// --- Create a tls.pem cert signed by the CA ---
+		tlsTemplate := x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			Subject: pkix.Name{
+				CommonName:   "localhost",
+				Organization: []string{"TestOrg"},
+			},
+			DNSNames:    []string{"localhost"},
+			NotBefore:   time.Now(),
+			NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+			KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		tlsKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.Nil(t, err)
+		tlsCertDER, err := x509.CreateCertificate(rand.Reader, &tlsTemplate, caCert, &tlsKey.PublicKey, caKey)
+		require.Nil(t, err)
+		tlsCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: tlsCertDER})
+		require.Nil(t, fsS.Certs.WriteFile(storage.CertsTlsPemFile, tlsCertPEM))
+
+		deviceCa, err = LoadDeviceCa(fsS)
+		require.Nil(t, err)
+		require.NotNil(t, deviceCa)
+	}
+
 	log, err := context.InitLogger("debug")
 	require.Nil(t, err)
 	ctx = CtxWithLog(ctx, log)
@@ -237,7 +303,7 @@ func NewTestClient(t *testing.T) *testClient {
 		Username:      "root",
 		AllowedScopes: 0,
 	}
-	RegisterHandlers(e, nil, apiS, &testAuthProvider{user: u})
+	RegisterHandlers(e, deviceCa, apiS, &testAuthProvider{user: u})
 
 	tc := testClient{
 		t:   t,
@@ -970,6 +1036,70 @@ data: {"uuid":"test-device-1","correlationId":"uuid-1","target-name":"intel-core
 	tc.assertDone(done3)
 
 	// TODO: Add rollout tail tests
+}
+
+func TestApiDeviceCreate(t *testing.T) {
+	tc := NewTestClientWithCA(t, "test-ou")
+	tc.u.AllowedScopes = users.ScopeDevicesC
+
+	// Generate device key and CSR
+	devKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.Nil(t, err)
+	devCsrTemplate := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         "test-uuid-1",
+			OrganizationalUnit: []string{"test-ou"},
+		},
+	}
+	devCsrDER, err := x509.CreateCertificateRequest(rand.Reader, &devCsrTemplate, devKey)
+	require.Nil(t, err)
+	devCsrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: devCsrDER})
+
+	// Create device via API
+	req := DeviceCreateRequest{
+		Uuid:       "test-uuid-1",
+		Name:       "test-device",
+		Group:      "",
+		HardwareId: "hwid-1",
+		Csr:        string(devCsrPEM),
+	}
+	body, err := json.Marshal(req)
+	require.Nil(t, err)
+	resp := tc.POST("/devices", http.StatusCreated, bytes.NewReader(body), "content-type", "application/json")
+	tc.POST("/devices", http.StatusConflict, bytes.NewReader(body), "content-type", "application/json")
+
+	time.Sleep(500 * time.Millisecond) // Ensure any previous rate limit buckets are reset
+	var devResp DeviceCreateResponse
+	require.Nil(t, json.Unmarshal(resp, &devResp))
+	assert.Contains(t, devResp.RootCrt, "BEGIN CERTIFICATE")
+	assert.Contains(t, devResp.ClientPem, "BEGIN CERTIFICATE")
+	assert.Contains(t, devResp.SotaToml, "compose_apps_proxy = \"")
+
+	// Try a bad OU
+	devCsrTemplate = x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:         "test-uuid-2",
+			OrganizationalUnit: []string{"bad-ou"},
+		},
+	}
+	devCsrDER, err = x509.CreateCertificateRequest(rand.Reader, &devCsrTemplate, devKey)
+	require.Nil(t, err)
+	devCsrPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: devCsrDER})
+	req = DeviceCreateRequest{
+		Uuid:       "test-uuid-2",
+		Name:       "test-devic",
+		Group:      "",
+		HardwareId: "hwid-1",
+		Csr:        string(devCsrPEM),
+	}
+	body, err = json.Marshal(req)
+	require.Nil(t, err)
+	tc.POST("/devices", http.StatusBadRequest, bytes.NewReader(body), "content-type", "application/json")
+
+	// Test rate limiting by sending rapid requests - 1st should succeed, next will be rate limited
+	time.Sleep(500 * time.Millisecond) // Ensure any previous rate limit buckets are reset
+	tc.POST("/devices", http.StatusBadRequest, bytes.NewReader(body), "content-type", "application/json")
+	tc.POST("/devices", http.StatusTooManyRequests, bytes.NewReader(body), "content-type", "application/json")
 }
 
 func TestApiDeviceDelete(t *testing.T) {

--- a/server/ui/server.go
+++ b/server/ui/server.go
@@ -4,12 +4,11 @@
 package ui
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/foundriesio/update-server/auth"
+	"github.com/foundriesio/update-server/context"
 	"github.com/foundriesio/update-server/server"
 	apiHandlers "github.com/foundriesio/update-server/server/ui/api"
 	"github.com/foundriesio/update-server/server/ui/daemons"
@@ -27,6 +26,7 @@ type daemon interface {
 }
 
 func NewServer(ctx context.Context, db *storage.DbHandle, fs *storage.FsHandle, bindAddr string) (server.Server, error) {
+	log := context.CtxGetLog(ctx)
 	strg, err := api.NewStorage(db, fs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load %s storage: %w", serverName, err)
@@ -48,13 +48,20 @@ func NewServer(ctx context.Context, db *storage.DbHandle, fs *storage.FsHandle, 
 	if err != nil {
 		return nil, err
 	}
-	slog.Info("Using authentication provider", "name", provider.Name())
+	log.Info("Using authentication provider", "name", provider.Name())
 
 	daemons := daemons.New(ctx, strg, users)
 
+	ca, err := apiHandlers.LoadDeviceCa(fs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load device CA: %w", err)
+	} else if ca != nil {
+		log.Info("Device CA is configured, enabling device registration endpoint")
+	}
+
 	srv := server.NewServer(ctx, e, serverName, bindAddr, nil)
 	e.Use(auth.CsrfCheck)
-	apiHandlers.RegisterHandlers(e, strg, provider)
+	apiHandlers.RegisterHandlers(e, ca, strg, provider)
 	webHandlers.RegisterHandlers(e, users, provider, branding, fs.Config.BrandingDir(), pageBuilder)
 	return &apiServer{server: srv, daemons: daemons}, nil
 }

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -126,6 +126,7 @@ type Storage struct {
 	stmtDeviceGetLabels  stmtDeviceGetLabels
 	stmtDeviceList       map[OrderBy]stmtDeviceList
 	stmtDeniedDeviceList stmtDeniedDeviceList
+	stmtDevicePut        stmtDevicePut
 	stmtUndenyDevice     stmtUndenyDevice
 	stmtDeviceSetLabels  stmtDeviceSetLabels
 	stmtDeviceSetUpdate  stmtDeviceSetUpdate
@@ -210,6 +211,7 @@ func NewStorage(db *storage.DbHandle, fs *storage.FsHandle) (*Storage, error) {
 		&handle.stmtUndenyDevice,
 		&handle.stmtDeviceSetLabels,
 		&handle.stmtDeviceSetUpdate,
+		&handle.stmtDevicePut,
 		&handle.stmtUpdateInsert,
 		&handle.stmtUpdateList,
 	); err != nil {
@@ -350,6 +352,10 @@ var clearingEventTypes = []string{"EcuInstallationCompleted", "CertRotationCompl
 // ListUpdates returns a map of tag to updates. If the tag is empty, it returns all tags.
 func (s Storage) ListUpdates(tag string) (map[string][]Update, error) {
 	return s.stmtUpdateList.run(tag)
+}
+
+func (s Storage) DeviceCreate(uuid, pubkey string, labels Labels) error {
+	return s.stmtDevicePut.run(uuid, pubkey, labels)
 }
 
 func (s Storage) GetUpdateTufMetadata(tag, updateName string) (map[string]map[string]any, error) {
@@ -801,6 +807,24 @@ func (s *stmtDeviceDelete) Init(db storage.DbHandle) (err error) {
 
 func (s *stmtDeviceDelete) run(uuid string) error {
 	_, err := s.Stmt.Exec(uuid)
+	return err
+}
+
+type stmtDevicePut storage.DbStmt
+
+func (s *stmtDevicePut) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("apiDevicePut", `
+		INSERT INTO devices (uuid, pubkey, labels, deleted, last_seen, created_at)
+		VALUES (?, ?, ?, false, 0, unixepoch())`)
+	return
+}
+
+func (s *stmtDevicePut) run(uuid, pubkey string, labels Labels) error {
+	labelsJson, err := json.Marshal(labels)
+	if err != nil {
+		return fmt.Errorf("unexpected error marshalling labels to JSON: %w", err)
+	}
+	_, err = s.Stmt.Exec(uuid, pubkey, labelsJson)
 	return err
 }
 

--- a/storage/pem_helpers.go
+++ b/storage/pem_helpers.go
@@ -1,0 +1,35 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package storage
+
+import (
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func PemBytesToObject[T any](pemBytes []byte, parse func([]byte) (T, error)) (T, error) {
+	first, rest := pem.Decode(pemBytes)
+	if first == nil || len(strings.TrimSpace(string(rest))) > 0 {
+		var zero T
+		return zero, fmt.Errorf("malformed PEM data")
+	}
+
+	return parse(first.Bytes)
+}
+
+func LoadPemFile[T any](path string, parse func([]byte) (T, error)) (T, error) {
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("unable to read %s: %w", path, err)
+	}
+	obj, err := PemBytesToObject(pemBytes, parse)
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("%w for %s", err, path)
+	}
+	return obj, nil
+}

--- a/storage/users/scopes.go
+++ b/storage/users/scopes.go
@@ -26,6 +26,7 @@ const (
 
 	ScopeDevicesR  = scopeR << scopeShiftDevices
 	ScopeDevicesRU = (scopeU | scopeR) << scopeShiftDevices
+	ScopeDevicesC  = scopeC << scopeShiftDevices
 	ScopeDevicesD  = scopeD << scopeShiftDevices
 
 	ScopeUpdatesR  = scopeR << scopeShiftUpdates
@@ -40,6 +41,7 @@ const (
 var maskToString = map[Scopes]string{
 	ScopeDevicesR:  "devices:read",
 	ScopeDevicesRU: "devices:read-update",
+	ScopeDevicesC:  "devices:create",
 	ScopeDevicesD:  "devices:delete",
 
 	ScopeUpdatesR:  "updates:read",


### PR DESCRIPTION
This set of changes adds support for the LmP's lmp-device-register if the user provides the "-T <token>" option.

Support for OAuth2 Device Flow will follow in a separate PR.

Fixes issue #207 