### PR TITLE
Add basic e2e testing

### DIFF
--- a/.github/workflows/contrib-test.yml
+++ b/.github/workflows/contrib-test.yml
@@ -49,3 +49,19 @@ jobs:
           trap 'docker compose --project-directory ./contrib down' EXIT
           sleep 3s
           ./contrib/fake-device.py -d .compose-server-data/fake-devices/device-1 /device
+
+  e2e-builds:
+    name: e2e-builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24'
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Check that e2e test can build a test image
+        run: |
+           cd contrib/e2e
+           make build

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,32 @@
+name: Post merge check
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build environment
+        run: |
+           cd contrib/e2e
+           make build
+
+      - name: Run tests
+        run: |
+           cd contrib/e2e
+           make run

--- a/contrib/e2e/.gitignore
+++ b/contrib/e2e/.gitignore
@@ -1,0 +1,2 @@
+.cache
+__pycache__

--- a/contrib/e2e/Dockerfile.fioup
+++ b/contrib/e2e/Dockerfile.fioup
@@ -1,0 +1,8 @@
+FROM golang:alpine AS builder
+
+RUN apk add --no-cache git make
+RUN git clone https://github.com/foundriesio/fioup
+RUN cd fioup && make build
+
+FROM docker:dind
+COPY --from=builder /go/fioup/bin/fioup /usr/local/bin/fioup

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -31,10 +31,12 @@ $(CACHE)/venv/bin/activate: requirements.txt
 	mkdir -p $(CACHE)
 	python3 -m venv $(CACHE)/venv
 	$(CACHE)/venv/bin/pip install -r requirements.txt
+	$(CACHE)/venv/bin/playwright install chromium
 
 run: build
 	$(CACHE)/venv/bin/pytest -s -v test_connection.py
 	$(CACHE)/venv/bin/pytest -s -v test_fiocli.py
+	$(CACHE)/venv/bin/pytest -s -v test_remote_actions.py
 
 clean:
 	rm -rf .cache 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -37,6 +37,7 @@ run: build
 	$(CACHE)/venv/bin/pytest -s -v test_connection.py
 	$(CACHE)/venv/bin/pytest -s -v test_fiocli.py
 	$(CACHE)/venv/bin/pytest -s -v test_remote_actions.py
+	$(CACHE)/venv/bin/pytest -s -v test_updates.py
 	$(CACHE)/venv/bin/pytest -s -v test_webui.py
 	$(CACHE)/venv/bin/pytest -s -v test_webui_settings.py
 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -34,6 +34,7 @@ $(CACHE)/venv/bin/activate: requirements.txt
 
 run: build
 	$(CACHE)/venv/bin/pytest -s -v test_connection.py
+	$(CACHE)/venv/bin/pytest -s -v test_fiocli.py
 
 clean:
 	rm -rf .cache 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -38,6 +38,7 @@ run: build
 	$(CACHE)/venv/bin/pytest -s -v test_fiocli.py
 	$(CACHE)/venv/bin/pytest -s -v test_remote_actions.py
 	$(CACHE)/venv/bin/pytest -s -v test_webui.py
+	$(CACHE)/venv/bin/pytest -s -v test_webui_settings.py
 
 clean:
 	rm -rf .cache 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -37,6 +37,7 @@ run: build
 	$(CACHE)/venv/bin/pytest -s -v test_connection.py
 	$(CACHE)/venv/bin/pytest -s -v test_fiocli.py
 	$(CACHE)/venv/bin/pytest -s -v test_remote_actions.py
+	$(CACHE)/venv/bin/pytest -s -v test_webui.py
 
 clean:
 	rm -rf .cache 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -40,6 +40,7 @@ run: build
 	$(CACHE)/venv/bin/pytest -s -v test_updates.py
 	$(CACHE)/venv/bin/pytest -s -v test_webui.py
 	$(CACHE)/venv/bin/pytest -s -v test_webui_settings.py
+	$(CACHE)/venv/bin/pytest -s -v test_e2e_update_flow.py
 
 clean:
 	rm -rf .cache 

--- a/contrib/e2e/Makefile
+++ b/contrib/e2e/Makefile
@@ -1,0 +1,39 @@
+.PHONY: fioup-vm build clean
+
+CACHE := .cache
+
+build: fioup-e2e $(CACHE)/fioserver $(CACHE)/fiocli $(CACHE)/composectl venv
+
+fioup-e2e: $(CACHE)/fioup-e2e.stamp
+$(CACHE)/fioup-e2e.stamp: Dockerfile.fioup
+	mkdir -p $(CACHE)
+	docker build -t fioup-e2e -f Dockerfile.fioup .
+	touch $@
+
+$(CACHE)/fioserver:
+	mkdir -p $(CACHE)
+	make -C ../.. fioserver
+	cp ../../bin/fioserver $(CACHE)/fioserver
+
+$(CACHE)/fiocli:
+	mkdir -p $(CACHE)
+	make -C ../.. fiocli-linux-amd64
+	cp ../../bin/fiocli-linux-amd64 $(CACHE)/fiocli
+
+$(CACHE)/composectl:
+	mkdir -p $(CACHE)
+	curl -fsSL -o $@ \
+	  https://github.com/foundriesio/composeapp/releases/download/v96.2.1/composectl_96.2.1_linux_amd64
+	chmod +x $@
+
+venv: $(CACHE)/venv/bin/activate
+$(CACHE)/venv/bin/activate: requirements.txt
+	mkdir -p $(CACHE)
+	python3 -m venv $(CACHE)/venv
+	$(CACHE)/venv/bin/pip install -r requirements.txt
+
+run: build
+	$(CACHE)/venv/bin/pytest -s -v test_connection.py
+
+clean:
+	rm -rf .cache 

--- a/contrib/e2e/README.md
+++ b/contrib/e2e/README.md
@@ -1,0 +1,98 @@
+# End-to-end tests
+
+This directory contains an end-to-end (e2e) test suite that exercises a real
+`update-server` together with a real device client (`fioup`). Unlike the unit
+tests, these tests stand up the actual server binary, register a real device,
+and drive genuine update, config, and remote-action flows through both the
+`fiocli` CLI and the web UI.
+
+## What gets run
+
+Each test session wires together three moving parts:
+
+- **update-server** — the `fioserver` binary, built from this repo, started with
+  a freshly generated PKI and a temporary data directory. It listens on
+  `:8080` (web UI + user API) and `:8443` (device API).
+- **fioup device** — a privileged `docker:dind` container (see
+  `Dockerfile.fioup`) with the [`fioup`](https://github.com/foundriesio/fioup)
+  client pre-installed. It plays the role of a real device: it checks in,
+  applies configs, runs remote actions, and installs compose-app updates.
+- **fiocli / Playwright** — the `fiocli` CLI (built from this repo) and a
+  headless Chromium browser drive the server the way an operator would.
+
+The container runs in its own network namespace with
+`--add-host=update-server:host-gateway`, so the `update-server` DNS name inside
+the container resolves back to the server running on the host.
+
+## Requirements
+
+The following tools must be available on the host:
+
+- `docker` (with permission to run privileged containers)
+- `openssl`
+- `python3` with `venv`
+- `make`, `git`, `curl`, and a Go toolchain (to build `fioserver` / `fiocli`)
+
+`make build` provisions everything else — the `fioup-e2e` image, the server and
+CLI binaries, `composectl`, a Python virtualenv, and Playwright's Chromium.
+
+## Running the tests
+
+From this directory:
+
+```
+make run
+```
+
+This builds any missing dependencies and then runs each test module in turn.
+Build artifacts are cached under `.cache/` (which is git-ignored), so
+subsequent runs only rebuild what changed.
+
+To build the dependencies without running the tests:
+
+```
+make build
+```
+
+To run an individual test module against an already-built environment, use the
+virtualenv's pytest directly:
+
+```
+.cache/venv/bin/pytest -s -v test_e2e_update_flow.py
+```
+
+To start fresh (remove all cached binaries, the venv, and the update artifact):
+
+```
+make clean
+```
+
+## The tests
+
+| Module | What it covers |
+| --- | --- |
+| `test_connection.py` | Sanity: a device checks in and appears in the server; `lmp-device-register`-style registration. |
+| `test_fiocli.py` | `fiocli devices list/show`; pushing a config and confirming `fioup` applies it on the device. |
+| `test_remote_actions.py` | `fioup run-and-report`; verifying the result via CLI and the web UI, plus artifact download. |
+| `test_updates.py` | Uploading an OTA update artifact and finding it in `updates list`. |
+| `test_webui.py` | Web UI smoke tests and device-table rendering. |
+| `test_webui_settings.py` | Creating an API token via the settings dialog and checking the audit log. |
+| `test_e2e_update_flow.py` | Full flow: upload an update, create a rollout, install on the device, and verify events plus the running container. |
+
+## How the fixtures fit together
+
+The shared fixtures live in `conftest.py` and are session-scoped, so the server
+and device are set up once per run:
+
+- `update_server` — generates PKI (`add_device.sh` signs a device cert against
+  the generated device CA), initializes TUF and test-mode auth, and starts
+  `fioserver serve`, yielding its data directory.
+- `fioup_device` / `docker` — launch the `fioup` container and wait for its
+  inner `dockerd` to be ready.
+- `registered_device` — copies the generated device credentials plus a
+  `sota.toml` into the container and runs `fioup check` so the device shows up
+  on the server.
+- `fiocli` / `fiocli_tail` — a logged-in `fiocli` caller, and a variant that
+  tails a command in the background.
+- `sample_update` — pulls a sample compose-app (`shellhttpd`) with `composectl`
+  to use as the update payload; cached across runs.

--- a/contrib/e2e/add_device.sh
+++ b/contrib/e2e/add_device.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Generate device credentials and sign the CSR with a self-signed root CA.
+# Usage: add_device.sh <DATA_DIR> [HOSTNAME] [FACTORY]
+
+DATA_DIR=$1
+HOSTNAME=${2:-update-server}
+FACTORY=${3:-e2e-factory}
+
+if [ -z "$DATA_DIR" ]; then
+    echo "Usage: $0 <data_dir> [hostname] [factory]"
+    exit 1
+fi
+
+ls ${DATA_DIR}/certs 1>&2
+mkdir -p "${DATA_DIR}/device"
+openssl ecparam -genkey -name prime256v1 | openssl ec -out "${DATA_DIR}/device/pkey.pem" 2>/dev/null
+
+DEVICE_UUID=$(cat /proc/sys/kernel/random/uuid)
+cat >"${DATA_DIR}/device/device.cnf" <<EOF
+[req]
+prompt = no
+distinguished_name = dn
+req_extensions = ext
+
+[dn]
+CN = ${DEVICE_UUID}
+OU = ${FACTORY}
+
+[ext]
+keyUsage=critical, digitalSignature
+extendedKeyUsage=critical, clientAuth
+EOF
+
+openssl req -new -config "${DATA_DIR}/device/device.cnf" \
+    -key "${DATA_DIR}/device/pkey.pem" \
+    -out "${DATA_DIR}/device/device.csr"
+
+cat >"${DATA_DIR}/device/ca.ext" <<EOF
+keyUsage=keyCertSign
+extendedKeyUsage=critical, clientAuth
+basicConstraints=CA:TRUE
+EOF
+
+openssl x509 -req -days 3650 \
+    -in "${DATA_DIR}/device/device.csr" \
+    -CAcreateserial \
+    -extfile "${DATA_DIR}/device/ca.ext" \
+    -CAkey "${DATA_DIR}/certs/device-ca.key" \
+    -CA "${DATA_DIR}/certs/device-ca.crt" \
+    -out "${DATA_DIR}/device/client.pem"
+
+cp "${DATA_DIR}/certs/root.crt" "${DATA_DIR}/device/root.crt"
+rm "${DATA_DIR}/device/device.cnf" "${DATA_DIR}/device/device.csr" "${DATA_DIR}/device/ca.ext"
+
+echo "## Device certs: ${DATA_DIR}/device/{root.crt,client.pem,pkey.pem}"

--- a/contrib/e2e/conftest.py
+++ b/contrib/e2e/conftest.py
@@ -254,23 +254,6 @@ def registered_device(update_server, fioup_device) -> dict:
 def update_server(request, fioserver_bin):
     """Generate PKI, start update-server; yield datadir Path."""
     datadir = Path(tempfile.mkdtemp(prefix="fioserver-"))
-    gen_pki = REPO_ROOT / "gen_pki.sh"
-
-    print("\n[setup] Generating PKI ...", flush=True)
-    result = subprocess.run(
-        [
-            "bash",
-            str(gen_pki),
-            str(datadir),
-            str(fioserver_bin),
-            "update-server",
-            "e2e-factory",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    print(result.stdout)
 
     print("[setup] Initialising auth (noauth/test mode) ...", flush=True)
     subprocess.run(
@@ -278,6 +261,25 @@ def update_server(request, fioserver_bin):
         check=True,
         capture_output=True,
     )
+    
+    print("\n[setup] Generating PKI ...", flush=True)
+    subprocess.run(
+        [str(fioserver_bin), "--datadir", str(datadir), "pki-init", "--dnsname", "update-server", "--factory", "e2e-factory"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+        str(REPO_ROOT / "add_device.sh"),
+        str(datadir),
+        "update-server",
+        "e2e-factory",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
     subprocess.run(
         [str(fioserver_bin), "--datadir", str(datadir), "tuf-init"],
         check=True,

--- a/contrib/e2e/conftest.py
+++ b/contrib/e2e/conftest.py
@@ -117,6 +117,19 @@ class DockerClient:
             self.put(Path(tmp.name), dst)
 
 
+class ContainerDocker:
+    """Invokes the docker CLI against the dockerd running inside the container.
+
+    Usage: docker("ps"), docker("images"), ...
+    """
+
+    def __init__(self, client: "DockerClient"):
+        self._client = client
+
+    def __call__(self, args: str, check: bool = True) -> tuple[str, str]:
+        return self._client.run(f"docker {args}", check=check)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def preflight():
     _check_tools()
@@ -186,6 +199,26 @@ def fioup_device(preflight):
             container.remove(force=True)
         except docker_sdk.errors.NotFound:
             pass
+
+
+@pytest.fixture(scope="session")
+def docker(fioup_device) -> ContainerDocker:
+    """Wait for the in-container dockerd to be ready and yield a docker caller.
+
+    Usage: docker("ps"), docker("images"), ...
+    """
+    print("\n[setup] Waiting for dockerd in container ...", flush=True)
+    deadline = time.time() + 60
+    while True:
+        try:
+            fioup_device.run("docker info")
+            break
+        except RuntimeError:
+            if time.time() > deadline:
+                raise TimeoutError("dockerd did not become ready within 60s")
+            time.sleep(2)
+    print("[setup] Dockerd ready", flush=True)
+    return ContainerDocker(fioup_device)
 
 
 @pytest.fixture(scope="session")
@@ -317,6 +350,45 @@ def fiocli(fiocli_bin, update_server):
         "http://localhost:8080",
     )
     return lambda *args: _run_fiocli(fiocli_bin, home, *args)
+
+
+@pytest.fixture(scope="session")
+def fiocli_tail(fiocli_bin, update_server):
+    """Return a factory that starts a fiocli subcommand in a background thread.
+
+    Usage::
+
+        stop = fiocli_tail("updates", "tail", ...)
+        # ... do work ...
+        output = stop()   # terminates the process and returns collected stdout
+    """
+    home = update_server / "fiocli-home"
+
+    def _start(*args):
+        buf = []
+        proc = subprocess.Popen(
+            [str(fiocli_bin), *args],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True,
+            env={**os.environ, "HOME": str(home)},
+        )
+
+        def _reader():
+            for line in proc.stdout:
+                buf.append(line)
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+
+        def stop():
+            proc.terminate()
+            proc.wait(timeout=10)
+            t.join(timeout=5)
+            return "".join(buf)
+
+        return stop
+
+    return _start
 
 
 @pytest.fixture(scope="session")

--- a/contrib/e2e/conftest.py
+++ b/contrib/e2e/conftest.py
@@ -27,6 +27,11 @@ CACHE_DIR = REPO_ROOT / ".cache"
 CONTAINER_NAME = "fioup-e2e"
 SERVER_UI_PORT = 8080
 
+APP_IMAGE = (
+    "hub.foundries.io/lmp/shellhttpd"
+    "@sha256:589b63dd3ab24a016472145101858fc5124970c10ef5cabfb8d877b90e198603"
+)
+
 SOTA_TOML = """\
 [import]
 tls_cacert_path = "/var/sota/root.crt"
@@ -312,3 +317,37 @@ def fiocli(fiocli_bin, update_server):
         "http://localhost:8080",
     )
     return lambda *args: _run_fiocli(fiocli_bin, home, *args)
+
+
+@pytest.fixture(scope="session")
+def sample_update(composectl_bin) -> Path:
+    """Build the OTA update artifact in .cache/update/ (cached across sessions).
+
+    Structure:
+      .cache/update/apps/  -  OCI app bundle from composectl pull
+    """
+    print("[setup] Creating sample update content ...", flush=True)
+    update_dir = CACHE_DIR / "update"
+    apps_dir = update_dir / "apps"
+
+    if apps_dir.exists() and any(apps_dir.iterdir()):
+        return update_dir
+
+    apps_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        subprocess.check_output(
+            [
+                composectl_bin,
+                "pull",
+                f"-i{apps_dir}",
+                f"-s{apps_dir}",
+                APP_IMAGE,
+            ],
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"[setup] composectl pull failed: {e}", flush=True)
+        if e.stderr:
+            print(e.stderr, flush=True)
+        raise
+    return update_dir

--- a/contrib/e2e/conftest.py
+++ b/contrib/e2e/conftest.py
@@ -1,0 +1,133 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""pytest fixtures for update-server + fioup e2e tests."""
+
+import io
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import docker as docker_sdk
+import pytest
+
+REPO_ROOT = Path(__file__).parent
+CACHE_DIR = REPO_ROOT / ".cache"
+
+CONTAINER_NAME = "fioup-e2e"
+SERVER_UI_PORT = 8080
+
+
+def _check_tools():
+    missing = []
+    for tool in ("docker", "openssl"):
+        if not shutil.which(tool):
+            missing.append(tool)
+    for tool in [
+        "composectl",
+        "fioserver",
+        "fiocli",
+    ]:
+        if not (CACHE_DIR / tool).exists():
+            missing.append(tool)
+    if missing:
+        sys.exit("Missing required host tools: " + ", ".join(missing))
+
+
+class DockerClient:
+    """Runs commands in the target container via the docker-py SDK."""
+
+    def __init__(self, container: "docker_sdk.models.containers.Container"):
+        self._container = container
+
+    def run(self, cmd: str, check: bool = True) -> tuple[str, str]:
+        res = self._container.exec_run(["sh", "-c", cmd], demux=True)
+        stdout_b, stderr_b = res.output
+        stdout = stdout_b.decode() if stdout_b else ""
+        stderr = stderr_b.decode() if stderr_b else ""
+        if check and res.exit_code != 0:
+            raise RuntimeError(
+                f"Command failed (rc={res.exit_code}): {cmd!r}\n"
+                f"stdout={stdout}\nstderr={stderr}"
+            )
+        return stdout, stderr
+
+
+@pytest.fixture(scope="session", autouse=True)
+def preflight():
+    _check_tools()
+
+
+@pytest.fixture(scope="session")
+def fioserver_bin(preflight) -> Path:
+    return CACHE_DIR / "fioserver"
+
+
+@pytest.fixture(scope="session")
+def fiocli_bin(preflight) -> Path:
+    return CACHE_DIR / "fiocli"
+
+
+@pytest.fixture(scope="session")
+def composectl_bin(preflight) -> Path:
+    return CACHE_DIR / "composectl"
+
+
+@pytest.fixture(scope="session")
+def fioup_device(preflight):
+    """Launch the fioup target container and yield a docker-exec client.
+
+    The container image has fioup pre-installed. It runs privileged (docker:dind)
+    so fioup can manage compose apps; commands are executed via `docker exec`.
+    """
+    docker_client = docker_sdk.from_env()
+
+    # Remove any stale container left over from a previous run
+    try:
+        docker_client.containers.get(CONTAINER_NAME).remove(force=True)
+    except docker_sdk.errors.NotFound:
+        pass
+
+    print("\n[setup] Starting fioup container ...", flush=True)
+    container = docker_client.containers.run(
+        CONTAINER_NAME,
+        detach=True,
+        auto_remove=True,
+        privileged=True,
+        name=CONTAINER_NAME,
+        # Give the container its own network namespace so the inner dind daemon
+        # binds published ports (e.g. shellhttpd's 8080) in isolation instead of
+        # on the host, avoiding conflicts with update-server. The "update-server"
+        # DNS name still resolves to the host running the server locally.
+        extra_hosts={"update-server": "host-gateway"},
+    )
+
+    client = DockerClient(container)
+    try:
+        # Wait for the container to be ready for `docker exec`
+        deadline = time.time() + 30
+        while True:
+            if container.exec_run("true").exit_code == 0:
+                break
+            if time.time() > deadline:
+                raise TimeoutError("Container did not become ready within 30s")
+            time.sleep(1)
+
+        print("[setup] Container ready", flush=True)
+        yield client
+
+    finally:
+        print("\n[teardown] Stopping fioup container ...", flush=True)
+        try:
+            container.remove(force=True)
+        except docker_sdk.errors.NotFound:
+            pass

--- a/contrib/e2e/conftest.py
+++ b/contrib/e2e/conftest.py
@@ -19,12 +19,49 @@ from pathlib import Path
 
 import docker as docker_sdk
 import pytest
+import requests
 
 REPO_ROOT = Path(__file__).parent
 CACHE_DIR = REPO_ROOT / ".cache"
 
 CONTAINER_NAME = "fioup-e2e"
 SERVER_UI_PORT = 8080
+
+SOTA_TOML = """\
+[import]
+tls_cacert_path = "/var/sota/root.crt"
+tls_clientcert_path = "/var/sota/client.pem"
+tls_pkey_path = "/var/sota/pkey.pem"
+
+[uptane]
+key_source = "file"
+polling_sec = 30
+repo_server = "https://update-server:8443/repo"
+
+[provision]
+primary_ecu_hardware_id = "intel-corei7-64"
+server = "https://update-server:8443"
+
+[pacman]
+compose_apps_root = "/var/sota/compose-apps"
+compose_apps_proxy = "https://update-server:8443/app-proxy-url"
+ostree_server = "https://update-server:8443/ostree"
+packages_file = "/usr/package.manifest"
+reset_apps = " "
+reset_apps_root = "/var/sota/reset-apps"
+tags = "main"
+type = "ostree+compose_apps"
+
+[storage]
+path = "/var/sota/"
+type = "sqlite"
+
+[tls]
+server = "https://update-server:8443"
+ca_source = "file"
+cert_source = "file"
+pkey_source = "file"
+"""
 
 
 def _check_tools():
@@ -60,6 +97,19 @@ class DockerClient:
                 f"stdout={stdout}\nstderr={stderr}"
             )
         return stdout, stderr
+
+    def put(self, src: Path, dst: str):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            tar.add(str(src), arcname=os.path.basename(dst))
+        buf.seek(0)
+        self._container.put_archive(os.path.dirname(dst) or "/", buf.getvalue())
+
+    def put_text(self, text: str, dst: str):
+        with tempfile.NamedTemporaryFile("w") as tmp:
+            tmp.write(text)
+            tmp.flush()
+            self.put(Path(tmp.name), dst)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -131,3 +181,134 @@ def fioup_device(preflight):
             container.remove(force=True)
         except docker_sdk.errors.NotFound:
             pass
+
+
+@pytest.fixture(scope="session")
+def registered_device(update_server, fioup_device) -> dict:
+    """Run fioup check-in and wait for the device to appear in update-server."""
+    print("[setup] Copying device credentials ...", flush=True)
+    fioup_device.run("mkdir -p /var/sota")
+    device_dir = update_server / "device"
+    fioup_device.put(device_dir / "root.crt", "/var/sota/root.crt")
+    fioup_device.put(device_dir / "client.pem", "/var/sota/client.pem")
+    fioup_device.put(device_dir / "pkey.pem", "/var/sota/pkey.pem")
+    fioup_device.put_text(SOTA_TOML, "/var/sota/sota.toml")
+
+    print("\n[setup] Running fioup check-in ...", flush=True)
+    stdout, stderr = fioup_device.run("fioup check", check=False)
+
+    try:
+        resp = requests.get(f"http://localhost:{SERVER_UI_PORT}/v1/devices", timeout=5)
+        resp.raise_for_status()
+        devices = resp.json()
+        if devices and devices[0].get("last-seen", 0) > 0:
+            device = devices[0]
+            print(f"[setup] Device registered: {device['uuid']}", flush=True)
+            return device
+    except requests.exceptions.RequestException as exc:
+        print(f"[setup] failed to checkin with: stdout({stdout}) stderr({stderr})", flush=True)
+        pytest.fail(f"update-server /v1/devices request failed: {exc}")
+
+    raise RuntimeError(f"Device did not appear in update-server: stdout({stdout}) stderr({stderr})")
+
+
+@pytest.fixture(scope="session")
+def update_server(request, fioserver_bin):
+    """Generate PKI, start update-server; yield datadir Path."""
+    datadir = Path(tempfile.mkdtemp(prefix="fioserver-"))
+    gen_pki = REPO_ROOT / "gen_pki.sh"
+
+    print("\n[setup] Generating PKI ...", flush=True)
+    result = subprocess.run(
+        [
+            "bash",
+            str(gen_pki),
+            str(datadir),
+            str(fioserver_bin),
+            "update-server",
+            "e2e-factory",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    print(result.stdout)
+
+    print("[setup] Initialising auth (noauth/test mode) ...", flush=True)
+    subprocess.run(
+        [str(fioserver_bin), "--datadir", str(datadir), "auth-init", "--test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [str(fioserver_bin), "--datadir", str(datadir), "tuf-init"],
+        check=True,
+        capture_output=True,
+    )
+
+    print("[setup] Starting update-server server ...", flush=True)
+    log_path = datadir / "server.log"
+    log_file = open(log_path, "w")
+    proc = subprocess.Popen(
+        [str(fioserver_bin), "serve", "--datadir", str(datadir)],
+        stdout=log_file,
+        stderr=log_file,
+    )
+
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        try:
+            requests.get(f"http://localhost:{SERVER_UI_PORT}", timeout=2)
+            break
+        except requests.exceptions.ConnectionError:
+            time.sleep(1)
+    else:
+        proc.kill()
+        log_file.close()
+        print(log_path.read_text())
+        raise RuntimeError("update-server did not start within 30s")
+
+    print(f"[setup] update-server running (pid={proc.pid})", flush=True)
+
+    yield datadir
+
+    proc.terminate()
+    proc.wait(timeout=10)
+    log_file.close()
+    if request.session.testsfailed:
+        print("\n[teardown] update-server log:\n" + log_path.read_text(), flush=True)
+    shutil.rmtree(datadir, ignore_errors=True)
+
+
+def _run_fiocli(fiocli_bin: Path, home: Path, *args) -> str:
+    try:
+        result = subprocess.run(
+            [str(fiocli_bin), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HOME": str(home)},
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"[fiocli] command failed: {' '.join(str(a) for a in args)}", flush=True)
+        if e.stderr:
+            print(e.stderr, flush=True)
+        raise
+    return result.stdout
+
+
+@pytest.fixture(scope="session")
+def fiocli(fiocli_bin, update_server):
+    """Log in once and return a callable that runs fiocli subcommands."""
+    home = update_server / "fiocli-home"
+    (home / ".config").mkdir(exist_ok=True, parents=True)
+    _run_fiocli(
+        fiocli_bin,
+        home,
+        "login",
+        "--token",
+        "doesnotmatter",
+        "pytestfixture",
+        "http://localhost:8080",
+    )
+    return lambda *args: _run_fiocli(fiocli_bin, home, *args)

--- a/contrib/e2e/gen_pki.sh
+++ b/contrib/e2e/gen_pki.sh
@@ -1,0 +1,97 @@
+#!/bin/bash -e
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Generate PKI for e2e tests: root CA, server TLS cert, device cert.
+# Usage: gen_pki.sh <DATA_DIR> <FIOSERVER_BIN> [HOSTNAME] [FACTORY]
+
+DATA_DIR=$1
+FIOSERVER_BIN=$2
+HOSTNAME=${3:-update-server}
+FACTORY=${4:-e2e-factory}
+
+if [ -z "$DATA_DIR" ] || [ -z "$FIOSERVER_BIN" ]; then
+    echo "Usage: $0 <data_dir> <fioserver_bin> [hostname] [factory]"
+    exit 1
+fi
+
+mkdir -p "${DATA_DIR}/certs"
+
+echo "## Generating TLS CSR via fioserver"
+"$FIOSERVER_BIN" --datadir "$DATA_DIR" create-csr --dnsname "$HOSTNAME" --factory "$FACTORY"
+
+echo "## Creating Root CA (OU=e2e-factory)"
+cd "${DATA_DIR}/certs"
+cat >ca.cnf <<EOF
+[req]
+prompt = no
+distinguished_name = dn
+x509_extensions = ext
+
+[dn]
+CN = Factory-CA
+OU = ${FACTORY}
+
+[ext]
+basicConstraints=CA:TRUE
+keyUsage = keyCertSign
+extendedKeyUsage = critical, clientAuth, serverAuth
+EOF
+
+openssl ecparam -genkey -name prime256v1 | openssl ec -out factory_ca.key 2>/dev/null
+openssl req -new -x509 -days 7300 -config ca.cnf -key factory_ca.key -out factory_ca.pem
+rm ca.cnf
+
+# cas.pem is the device CA list used by the server for mTLS
+cp factory_ca.pem cas.pem
+
+echo "## Signing TLS CSR"
+cd "$DATA_DIR"
+"$FIOSERVER_BIN" --datadir "$DATA_DIR" sign-csr \
+    --cakey "${DATA_DIR}/certs/factory_ca.key" \
+    --cacert "${DATA_DIR}/certs/factory_ca.pem"
+
+echo "## Creating device credentials"
+mkdir -p "${DATA_DIR}/device"
+openssl ecparam -genkey -name prime256v1 | openssl ec -out "${DATA_DIR}/device/pkey.pem" 2>/dev/null
+
+DEVICE_UUID=$(python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null || cat /proc/sys/kernel/random/uuid)
+cat >"${DATA_DIR}/device/device.cnf" <<EOF
+[req]
+prompt = no
+distinguished_name = dn
+req_extensions = ext
+
+[dn]
+CN = ${DEVICE_UUID}
+OU = ${FACTORY}
+
+[ext]
+keyUsage=critical, digitalSignature
+extendedKeyUsage=critical, clientAuth
+EOF
+
+openssl req -new -config "${DATA_DIR}/device/device.cnf" \
+    -key "${DATA_DIR}/device/pkey.pem" \
+    -out "${DATA_DIR}/device/device.csr"
+
+cat >"${DATA_DIR}/device/ca.ext" <<EOF
+keyUsage=keyCertSign
+extendedKeyUsage=critical, clientAuth
+basicConstraints=CA:TRUE
+EOF
+
+openssl x509 -req -days 3650 \
+    -in "${DATA_DIR}/device/device.csr" \
+    -CAcreateserial \
+    -extfile "${DATA_DIR}/device/ca.ext" \
+    -CAkey "${DATA_DIR}/certs/factory_ca.key" \
+    -CA "${DATA_DIR}/certs/factory_ca.pem" \
+    -out "${DATA_DIR}/device/client.pem"
+
+cp "${DATA_DIR}/certs/factory_ca.pem" "${DATA_DIR}/device/root.crt"
+rm "${DATA_DIR}/device/device.cnf" "${DATA_DIR}/device/device.csr" "${DATA_DIR}/device/ca.ext"
+
+echo "## PKI generation complete"
+echo "  Server TLS:   ${DATA_DIR}/certs/tls.pem"
+echo "  Device certs: ${DATA_DIR}/device/{root.crt,client.pem,pkey.pem}"

--- a/contrib/e2e/requirements.txt
+++ b/contrib/e2e/requirements.txt
@@ -1,3 +1,5 @@
 docker>=7.0
 pytest>=8
 requests>=2.31
+playwright>=1.40
+pytest-playwright>=0.4

--- a/contrib/e2e/requirements.txt
+++ b/contrib/e2e/requirements.txt
@@ -1,2 +1,3 @@
 docker>=7.0
 pytest>=8
+requests>=2.31

--- a/contrib/e2e/requirements.txt
+++ b/contrib/e2e/requirements.txt
@@ -1,0 +1,2 @@
+docker>=7.0
+pytest>=8

--- a/contrib/e2e/test_connection.py
+++ b/contrib/e2e/test_connection.py
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+
+def test_connection(fioup_device):
+    val = fioup_device.run("fioup version")
+    print("[test_connection]", val)

--- a/contrib/e2e/test_connection.py
+++ b/contrib/e2e/test_connection.py
@@ -3,6 +3,7 @@
 
 """E2E test: Sanity check that a device can connect to the update-server."""
 
+
 def test_connection(registered_device, fiocli):
     print("[test_connection] registered_device:", registered_device["uuid"])
     out = fiocli("devices", "list")
@@ -12,3 +13,13 @@ def test_connection(registered_device, fiocli):
     assert (
         last_seen > 0
     ), f"Device registered but last-seen is zero: {registered_device}"
+
+
+def test_device_register(fioup_device, fiocli):
+    uuid = "11111111-1111-1111-1111-111111111111"
+    fioup_device.run("rm -rf /var/sota/*")
+    fioup_device.run(f"DEVICE_API=http://update-server:8080/v1/devices fioup --verbose register --apps ' ' --uuid={uuid} --factory=e2e-factory --name=e2e-test-device --tag=main --api-token doesnotmatter")
+
+    out = fiocli("devices", "show", uuid)
+    print("[fiocli]", out)
+    assert "name: e2e-test-device" in out

--- a/contrib/e2e/test_connection.py
+++ b/contrib/e2e/test_connection.py
@@ -1,7 +1,14 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
+"""E2E test: Sanity check that a device can connect to the update-server."""
 
-def test_connection(fioup_device):
-    val = fioup_device.run("fioup version")
-    print("[test_connection]", val)
+def test_connection(registered_device, fiocli):
+    print("[test_connection] registered_device:", registered_device["uuid"])
+    out = fiocli("devices", "list")
+    print("[fiocli]", out)
+
+    last_seen = registered_device.get("last-seen", 0)
+    assert (
+        last_seen > 0
+    ), f"Device registered but last-seen is zero: {registered_device}"

--- a/contrib/e2e/test_e2e_update_flow.py
+++ b/contrib/e2e/test_e2e_update_flow.py
@@ -1,0 +1,45 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""E2E test: full update flow — register device, upload update, create rollout,
+install on device, verify events and running containers."""
+
+UPDATE_NAME = "e2e-update"
+ROLLOUT_NAME = "e2e-rollout"
+
+
+def test_full_update_flow(fiocli, fiocli_tail, sample_update, registered_device, fioup_device, docker):
+    uuid = registered_device["uuid"]
+
+    # Upload the update artifact
+    fiocli("updates", "upload", "--hardware-id=intel-corei7-64", "main", UPDATE_NAME, str(sample_update))
+
+    # Create a rollout targeting this specific device
+    fiocli(
+        "updates", "create-rollout",
+        "main", UPDATE_NAME, ROLLOUT_NAME,
+        "--uuids", uuid,
+    )
+
+    # Trigger the update on the device and wait for it to complete
+    fioup_device.run("fioup update")
+
+    # Tail the rollout in a background thread before triggering the update
+    stop_tail = fiocli_tail(
+        #"updates", "tail", "ci", "main", UPDATE_NAME, "--rollout", ROLLOUT_NAME,
+        "updates", "tail", "main", UPDATE_NAME,
+    )
+
+    # Verify update events are recorded for the device
+    out = fiocli("devices", "updates", uuid)
+    lines = out.splitlines()
+    out = fiocli("devices", "updates", uuid, lines[1].strip())
+
+    # Verify the shellhttpd compose app is running on the device
+    docker_out, _ = docker("ps")
+    assert "shellhttpd" in docker_out, f"shellhttpd container not running:\n{docker_out}"
+    assert "EcuInstallationCompleted(default-1) -> Succeeded" in out, f"Update events do not show successful installation:\n{docker_out}"
+
+    # Stop the tail and collect everything that was streamed
+    out = stop_tail()
+    assert '"status":"Installation completed; succeeded"' in out, f"Tail did not show successful installation event:\n{out}"

--- a/contrib/e2e/test_fiocli.py
+++ b/contrib/e2e/test_fiocli.py
@@ -1,0 +1,27 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""E2E test: fiocli CLI against a live update-server with a registered device."""
+
+
+def test_fiocli_workflow(fiocli, registered_device, fioup_device):
+    device_uuid = registered_device["uuid"]
+
+    # devices list
+    out = fiocli("devices", "list")
+    assert device_uuid in out, f"Device UUID not found in 'devices list':\n{out}"
+
+    # devices show
+    out = fiocli("devices", "show", device_uuid)
+    assert device_uuid in out, f"Device UUID not found in 'devices show':\n{out}"
+
+    # push a config entry to the device
+    fiocli("configs", "set", "testfile=testcontent")
+
+    # have fioup fetch and apply the config
+    fioup_device.run("fioup config-check")
+
+    # verify the file landed on the device with the expected content
+    fioup_device.run("test -f /run/secrets/testfile")
+    content, _ = fioup_device.run("cat /run/secrets/testfile")
+    assert content.strip() == "testcontent", f"Unexpected file content: {content!r}"

--- a/contrib/e2e/test_remote_actions.py
+++ b/contrib/e2e/test_remote_actions.py
@@ -1,0 +1,42 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""E2E test: remote actions — run a command on a device, verify via CLI and web UI."""
+
+SERVER_URL = "http://localhost:8080"
+
+
+def test_remote_actions(page, fiocli, registered_device, fioup_device):
+    uuid = registered_device["uuid"]
+
+    # Run a command on the device and report results back to the server
+    fioup_device.run("fioup run-and-report --name e2etest /bin/dmesg")
+
+    # Verify the test appears in the CLI listing
+    out = fiocli("devices", "tests", uuid)
+    assert "e2etest" in out, f"Test 'e2etest' not found in devices tests output:\n{out}"
+
+    # Parse the test ID from the first data row (header is line 0)
+    lines = [l for l in out.splitlines() if l.strip()]
+    name, status, test_id, _, _ = lines[1].split()
+    assert name == "e2etest", f"Expected test name 'e2etest' from {out}"
+    assert status == "PASSED", f"Expected test status 'PASSED' from {out}"
+
+    # Fetch the test detail to confirm it populated
+    detail = fiocli("devices", "tests", uuid, test_id)
+    assert "e2etest" in detail, f"Test detail does not contain 'e2etest':\n{detail}"
+
+    # Web UI: tests list page for the device
+    page.goto(f"{SERVER_URL}/devices/{uuid}/tests")
+    page.wait_for_load_state("networkidle")
+    assert "e2etest" in page.content(), "Tests list page does not show test name"
+
+    # Web UI: test detail page
+    page.goto(f"{SERVER_URL}/devices/{uuid}/tests/{test_id}")
+    page.wait_for_load_state("networkidle")
+    assert "e2etest" in page.content(), "Test detail page does not show test name"
+    assert test_id in page.content(), "Test detail page does not show test ID"
+
+    # Test artifact download
+    out = fiocli("devices", "tests", uuid, test_id, "console.log")
+    assert ("eth0: renamed from" in out), f"Expected console log not found:\n{out}"

--- a/contrib/e2e/test_updates.py
+++ b/contrib/e2e/test_updates.py
@@ -1,0 +1,15 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""E2E test: upload an OTA update to update-server via fiocli."""
+
+
+def test_update_upload(fiocli, sample_update):
+    """Upload the cached update artifact and verify it appears in the updates list."""
+    fiocli("updates", "upload", "main", "--hardware-id=amd64-linux", "fixture-update", str(sample_update))
+
+    out = fiocli("updates", "list")
+    assert "main  fixture-update" in out, f"Uploaded update not found in 'updates list':\n{out}"
+    
+    # TODO - once we merge the "cli-updates-show" branch out = fiocli("updates", "show", "main", "fixture-update")
+    # TODO - updates delete

--- a/contrib/e2e/test_webui.py
+++ b/contrib/e2e/test_webui.py
@@ -1,0 +1,60 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Web UI tests for update-server using Playwright."""
+
+import pytest
+
+SERVER_URL = "http://localhost:8080"
+
+# ── Static smoke tests (server only, no VM needed) ──────────────────────────
+
+
+def test_root_redirects_to_devices(page, update_server):
+    """/ redirects to /devices with the expected page title."""
+    page.goto(SERVER_URL)
+    assert page.url.endswith("/devices")
+    assert page.title() == "Devices - Foundries Update Server"
+
+
+def test_nav_links(page, update_server):
+    """Sub-navigation contains all expected section links."""
+    page.goto(f"{SERVER_URL}/devices")
+    subnav = page.locator("#subnav")
+    for label in ("Devices", "Configs", "Updates", "Users"):
+        assert subnav.get_by_role("link", name=label).is_visible()
+
+
+def test_configs_page_loads(page, update_server):
+    page.goto(f"{SERVER_URL}/configs")
+    assert page.title() == "Global Configs - Foundries Update Server"
+    assert page.get_by_role("heading", name="Global Configs").is_visible()
+    assert page.get_by_role("heading", name="Groups").is_visible()
+
+
+def test_updates_page_loads(page, update_server):
+    page.goto(f"{SERVER_URL}/updates")
+    assert page.title() == "Updates - Foundries Update Server"
+    assert page.get_by_role("heading", name="Updates").is_visible()
+
+
+# ── Device-dependent tests (require a registered device) ────────────────────
+
+
+def test_registered_device_in_table(page, registered_device):
+    """A registered device appears in the devices table."""
+    page.goto(f"{SERVER_URL}/devices")
+    uuid = registered_device["uuid"]
+    page.wait_for_selector(f"text={uuid}")
+    assert page.locator("tr", has_text=uuid).is_visible()
+
+
+def test_delete_dialog(page, registered_device):
+    """Clicking the trash icon opens the JS delete dialog with the device UUID."""
+    page.goto(f"{SERVER_URL}/devices")
+    uuid = registered_device["uuid"]
+    row = page.locator("tr", has_text=uuid)
+    row.locator("i.trash").click()
+    dialog = page.locator("#deleteDialog")
+    dialog.wait_for(state="visible")
+    assert page.locator("#deleteUuid").inner_text() == uuid

--- a/contrib/e2e/test_webui_settings.py
+++ b/contrib/e2e/test_webui_settings.py
@@ -1,0 +1,60 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Web UI tests for user settings — API token creation and audit log."""
+
+from datetime import date, timedelta
+
+SERVER_URL = "http://localhost:8080"
+
+
+def test_settings_api_token_and_audit_log(page, update_server):
+    """Create an API token via the settings dialog, verify it appears in the list,
+    then confirm the audit log records the creation."""
+    # Warm-up navigation: the noauth provider writes the CSRF cookie to the
+    # *response* on the first ever request, but the template reads .CsrfToken
+    # from the *incoming* request cookie — so the meta csrf-token tag is always
+    # absent on a brand-new browser context.  Navigating to root first lets the
+    # browser store the Set-Cookie, then the /settings request sends it back and
+    # the server can render the meta tag (and the page's fetch() wrapper can
+    # inject X-CSRF-Token automatically on subsequent AJAX calls).
+    page.goto(f"{SERVER_URL}/")
+    page.goto(f"{SERVER_URL}/settings")
+
+    # Open the New Token dialog
+    page.get_by_role("button", name="New Token").click()
+
+    dialog = page.locator("#tokenModal")
+    dialog.wait_for(state="visible")
+
+    dialog.get_by_label("description").fill("e2e test")
+    expires = (date.today() + timedelta(days=2)).strftime("%Y-%m-%d")
+    dialog.locator("input[type='date']").fill(expires)
+    dialog.locator("input[type='checkbox']").first.check()
+
+    # Register alert handler to catch any server-side error surfaced via JS alert()
+    js_dialog_message = None
+
+    def handle_alert(js_dialog):
+        nonlocal js_dialog_message
+        js_dialog_message = js_dialog.message
+        js_dialog.accept()
+
+    page.on("dialog", handle_alert)
+    dialog.get_by_role("button", name="Confirm").click()
+
+    # On success the server shows #tokenCreatedModal with the new API key value.
+    created_modal = page.locator("#tokenCreatedModal")
+    created_modal.wait_for(state="visible")
+    assert js_dialog_message is None, f"JavaScript alert: {js_dialog_message}"
+
+    # Dismiss the modal, then reload to verify the token appears in the list
+    created_modal.get_by_text("Close").click()
+    page.wait_for_load_state("networkidle")
+    assert "e2e test" in page.content(), "New API token not visible on settings page"
+
+    page.get_by_text("View audit log").click()
+    page.wait_for_load_state("networkidle")
+    assert (
+        "Token created" in page.content()
+    ), f"Audit log does not show API token creation event:\n{page.content()}"


### PR DESCRIPTION
This creates a simple way to do some primitive e2e testing of the update server using a "device" running fioup inside a docker:dind container. 

Once we agree on the general functionality of this, I'll propose some sort of periodic cron-based task to run these tests.