### PR TITLE
Add support for deleting old Updates

### DIFF
--- a/cli/api/updates.go
+++ b/cli/api/updates.go
@@ -104,3 +104,8 @@ func (u UpdatesApi) CreateUpdate(tag, updateName string, opts CreateUpdateOption
 	_, err := u.api.Post(endpoint, body, HttpHeader("Content-Type", "application/x-tar"), HttpHeader("Content-Encoding", "gzip"))
 	return err
 }
+
+func (u UpdatesApi) Delete(tag, updateName string) error {
+	endpoint := "/v1/updates/" + tag + "/" + updateName
+	return u.api.Delete(endpoint)
+}

--- a/cli/subcommands/updates/delete.go
+++ b/cli/subcommands/updates/delete.go
@@ -1,0 +1,24 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package updates
+
+import (
+	"github.com/foundriesio/update-server/cli/api"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete <tag> <update-name>",
+	Short: "Delete an update",
+	Long:  `Delete an update from the server. Fails if devices are still assigned to it.`,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		api := api.CtxGetApi(cmd.Context())
+		cobra.CheckErr(api.Updates().Delete(args[0], args[1]))
+	},
+}
+
+func init() {
+	UpdatesCmd.AddCommand(deleteCmd)
+}

--- a/cli/subcommands/updates/list.go
+++ b/cli/subcommands/updates/list.go
@@ -29,11 +29,11 @@ func listUpdates(api *api.Api) {
 	allUpdates, err := api.Updates().List()
 	cobra.CheckErr(err)
 
-	t := subcommands.NewTableWriter([]string{"TAG", "NAME", "UPLOADED AT", "UPLOADED BY"})
+	t := subcommands.NewTableWriter([]string{"TAG", "NAME", "UPLOADED AT", "DEVICE COUNT", "UPLOADED BY"})
 
 	for tag, updates := range allUpdates {
 		for _, update := range updates {
-			t.AddRow(tag, update.Name, time.Unix(update.UploadedAt, 0).Format(time.RFC3339), update.UploadedBy)
+			t.AddRow(tag, update.Name, time.Unix(update.UploadedAt, 0).Format(time.RFC3339), update.DeviceCount, update.UploadedBy)
 		}
 	}
 

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -70,6 +70,7 @@ func RegisterHandlers(e *echo.Echo, ca *DeviceCa, storage *storage.Storage, a au
 	// upd.GET("/:tag/:update", h.updateGet, requireScope(users.ScopeDevicesR))
 	upd.POST("/:tag/:update", h.updateCreate, requireScope(users.ScopeUpdatesRU),
 		gzipContentTypeAsContentEncoding, middleware.Decompress())
+	upd.DELETE("/:tag/:update", h.updateDelete, requireScope(users.ScopeUpdatesD))
 	upd.GET("/:tag/:update/tuf", h.updateGetTuf, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/rollouts", h.rolloutList, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/rollouts/:rollout", h.rolloutGet, requireScope(users.ScopeUpdatesR))

--- a/server/ui/api/handlers_test.go
+++ b/server/ui/api/handlers_test.go
@@ -710,6 +710,56 @@ func TestApiUpdateList(t *testing.T) {
 	tc.GET("/updates/bad^tag", 404)
 }
 
+func TestApiUpdateDelete(t *testing.T) {
+	tc := NewTestClient(t)
+
+	// Seed an update with an on-disk directory.
+	require.Nil(t, tc.api.InsertUpdate("tag1", "update1", "user1"))
+	require.Nil(t, tc.fs.Updates.Rollouts.WriteFile("tag1", "update1", "rollout1", "foo"))
+
+	// No permission / wrong scope.
+	tc.DELETE("/updates/tag1/update1", 403)
+	tc.u.AllowedScopes = users.ScopeUpdatesRU
+	tc.DELETE("/updates/tag1/update1", 403)
+
+	tc.u.AllowedScopes = users.ScopeUpdatesD
+
+	// 404 for a non-existent update.
+	tc.DELETE("/updates/tag1/no-such-update", 404)
+
+	// Synthetic tag/update validation must still return 404.
+	tc.DELETE("/updates/bad^tag/update42", 404)
+	tc.DELETE("/updates/tag/update=bad", 404)
+
+	updatesDir := tc.fs.Config.UpdatesDir()
+
+	// Successful delete removes both the DB row and the on-disk directory.
+	tc.DELETE("/updates/tag1/update1", 204)
+	updates, err := tc.api.ListUpdates("tag1")
+	require.Nil(t, err)
+	assert.Empty(t, updates["tag1"])
+	_, err = os.Stat(filepath.Join(updatesDir, "tag1", "update1"))
+	assert.True(t, os.IsNotExist(err))
+
+	// Deleting an update that a device is assigned to is a conflict.
+	require.Nil(t, tc.api.InsertUpdate("tag2", "update2", "user1"))
+	require.Nil(t, tc.fs.Updates.Rollouts.WriteFile("tag2", "update2", "rollout1", "foo"))
+	d, err := tc.gw.DeviceCreate("dev1", "pubkey1")
+	require.Nil(t, err)
+	require.Nil(t, d.CheckIn("", "tag2", "", ""))
+	_, err = tc.api.SetUpdateName("tag2", "update2", []string{"dev1"}, nil)
+	require.Nil(t, err)
+
+	tc.DELETE("/updates/tag2/update2", 409)
+
+	// The update and its directory survive the rejected delete.
+	updates, err = tc.api.ListUpdates("tag2")
+	require.Nil(t, err)
+	require.Len(t, updates["tag2"], 1)
+	_, err = os.Stat(filepath.Join(updatesDir, "tag2", "update2"))
+	require.NoError(t, err)
+}
+
 func TestApiRolloutList(t *testing.T) {
 	tc := NewTestClient(t)
 	tc.GET("/updates/tag/update/rollouts", 403)

--- a/server/ui/api/handlers_updates.go
+++ b/server/ui/api/handlers_updates.go
@@ -6,6 +6,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -63,6 +64,30 @@ func (h handlers) updateCreate(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusCreated)
+}
+
+// @Summary Delete an update
+// @Description Requires scope: updates:delete. Fails with 409 if any device is still assigned to the update.
+// @Tags    Updates
+// @Success 204
+// @Failure 404
+// @Failure 409
+// @Param   tag path string true "Update tag"
+// @Param   update path string true "Update name"
+// @Router  /updates/{tag}/{update} [delete]
+func (h handlers) updateDelete(c echo.Context) error {
+	tag := c.Param("tag")
+	update := c.Param("update")
+
+	if err := h.storage.DeleteUpdate(tag, update); err != nil {
+		if errors.Is(err, storage.ErrUpdateInUse) {
+			return EchoError(c, err, http.StatusConflict, "Update has devices assigned and cannot be deleted")
+		} else if errors.Is(err, os.ErrNotExist) {
+			return c.NoContent(http.StatusNotFound)
+		}
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to delete update")
+	}
+	return c.NoContent(http.StatusNoContent)
 }
 
 // parseAppsParam parses repeated "apps" query values of the form

--- a/server/ui/web/templates/updates.html
+++ b/server/ui/web/templates/updates.html
@@ -8,6 +8,7 @@
             <th>Tag</th>
             <th>Update name</th>
             <th>Uploaded at</th>
+            <th>Device count</th>
             <th>Uploaded by</th>
           </tr>
         </thead>
@@ -18,6 +19,7 @@
             <td>{{ $key }}</td>
             <td><a href="/updates/{{$key}}/{{ $update.Name }}">{{ $update.Name }}</a></td>
             <td>{{ tsToString $update.UploadedAt }}</td>
+            <td>{{ $update.DeviceCount }}</td>
             <td>{{ $update.UploadedBy }}</td>
           </tr>
           {{ end }}

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"iter"
 	"log/slog"
+	"os"
 	"slices"
 	"strings"
 
@@ -72,6 +73,7 @@ var (
 	IsDbError             = storage.IsDbError
 	ErrDbConstraintUnique = storage.ErrDbConstraintUnique
 	ErrInvalidUpdate      = storage.ErrInvalidUpdate
+	ErrUpdateInUse        = storage.ErrUpdateInUse
 )
 
 // DeviceListOpts lets you set the order devices will be returned
@@ -130,6 +132,7 @@ type Storage struct {
 	stmtUndenyDevice     stmtUndenyDevice
 	stmtDeviceSetLabels  stmtDeviceSetLabels
 	stmtDeviceSetUpdate  stmtDeviceSetUpdate
+	stmtUpdateDelete     stmtUpdateDelete
 	stmtUpdateInsert     stmtUpdateInsert
 	stmtUpdateList       stmtUpdateList
 }
@@ -214,6 +217,7 @@ func NewStorage(db *storage.DbHandle, fs *storage.FsHandle) (*Storage, error) {
 		&handle.stmtDevicePut,
 		&handle.stmtUpdateInsert,
 		&handle.stmtUpdateList,
+		&handle.stmtUpdateDelete,
 	); err != nil {
 		return nil, err
 	}
@@ -356,6 +360,20 @@ func (s Storage) ListUpdates(tag string) (map[string][]Update, error) {
 
 func (s Storage) DeviceCreate(uuid, pubkey string, labels Labels) error {
 	return s.stmtDevicePut.run(uuid, pubkey, labels)
+}
+
+// DeleteUpdate removes an update's database row and on-disk directory. It
+// refuses (returning ErrUpdateInUse) if any non-denied device is still assigned
+// to the update. It returns ErrNotExist if the update does not exist.
+func (s Storage) DeleteUpdate(tag, name string) error {
+	existed, err := s.stmtUpdateDelete.run(tag, name)
+	if err != nil {
+		return err
+	}
+	if !existed {
+		return os.ErrNotExist
+	}
+	return s.fs.Updates.Delete(tag, name)
 }
 
 func (s Storage) GetUpdateTufMetadata(tag, updateName string) (map[string]map[string]any, error) {
@@ -877,4 +895,29 @@ func (s *stmtUpdateList) run(tag string) (map[string][]Update, error) {
 		res[t] = append(res[t], u)
 	}
 	return res, rows.Err()
+}
+
+type stmtUpdateDelete storage.DbStmt
+
+func (s *stmtUpdateDelete) Init(db storage.DbHandle) (err error) {
+	s.Stmt, err = db.Prepare("apiUpdateDelete", `
+		DELETE FROM updates 
+		WHERE tag = ?
+  		AND name = ?;`)
+	return
+}
+
+func (s *stmtUpdateDelete) run(tag, name string) (bool, error) {
+	res, err := s.Stmt.Exec(tag, name)
+	if err != nil {
+		if err.Error() == ErrUpdateInUse.Error() {
+			return false, ErrUpdateInUse
+		}
+		return false, err
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected > 0, nil
 }

--- a/storage/api/api_storage.go
+++ b/storage/api/api_storage.go
@@ -851,9 +851,13 @@ type stmtUpdateList storage.DbStmt
 
 func (s *stmtUpdateList) Init(db storage.DbHandle) (err error) {
 	s.Stmt, err = db.Prepare("apiUpdateList", `
-		SELECT tag, name, uploaded_at, uploaded_by FROM updates
-		WHERE (? = '' OR tag = ?)
-		ORDER BY tag, uploaded_at, name`)
+		SELECT u.tag, u.name, u.uploaded_at, u.uploaded_by, COUNT(d.uuid)
+		FROM updates u
+		LEFT JOIN devices d
+			ON d.tag = u.tag AND d.update_name = u.name AND d.deleted = false
+		WHERE (? = '' OR u.tag = ?)
+		GROUP BY u.tag, u.name
+		ORDER BY u.tag, u.uploaded_at, u.name`)
 	return
 }
 
@@ -867,7 +871,7 @@ func (s *stmtUpdateList) run(tag string) (map[string][]Update, error) {
 	for rows.Next() {
 		var u Update
 		var t string
-		if err = rows.Scan(&t, &u.Name, &u.UploadedAt, &u.UploadedBy); err != nil {
+		if err = rows.Scan(&t, &u.Name, &u.UploadedAt, &u.UploadedBy, &u.DeviceCount); err != nil {
 			return nil, err
 		}
 		res[t] = append(res[t], u)

--- a/storage/api/api_storage_update_test.go
+++ b/storage/api/api_storage_update_test.go
@@ -5,12 +5,14 @@ package api
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/foundriesio/update-server/storage"
+	"github.com/foundriesio/update-server/storage/gateway"
 	storageTesting "github.com/foundriesio/update-server/storage/testing"
 	"github.com/foundriesio/update-server/storage/tuf"
 )
@@ -63,4 +65,65 @@ func TestCreateUpdateUsesUploadedTuf(t *testing.T) {
 	raw, err := s.fs.Updates.Tuf.ReadFile("main", "v1.0", storage.TufTargetsFile)
 	require.NoError(t, err)
 	assert.JSONEq(t, validTargets, raw)
+}
+
+func TestListUpdatesDeviceCount(t *testing.T) {
+	tmpdir := t.TempDir()
+	dbFile := filepath.Join(tmpdir, "sql.db")
+	db, err := storage.NewDb(dbFile)
+	require.NoError(t, err)
+	fs, err := storage.NewFs(tmpdir)
+	require.NoError(t, err)
+
+	s, err := NewStorage(db, fs)
+	require.NoError(t, err)
+
+	dg, err := gateway.NewStorage(db, fs)
+	require.NoError(t, err)
+
+	// Seed updates: two on "main", one on "dev".
+	require.NoError(t, s.InsertUpdate("main", "v1.0", "tester"))
+	require.NoError(t, s.InsertUpdate("main", "v2.0", "tester"))
+	require.NoError(t, s.InsertUpdate("dev", "v1.0", "tester"))
+
+	// Create and check in devices on the "main" tag.
+	for _, uuid := range []string{"uuid-1", "uuid-2", "uuid-3", "uuid-4"} {
+		d, err := dg.DeviceCreate(uuid, "pubkey-"+uuid)
+		require.NoError(t, err)
+		require.NoError(t, d.CheckIn("target", "main", "hash", ""))
+	}
+
+	// Assign two devices to v1.0 and one to v2.0.
+	assigned, err := s.SetUpdateName("main", "v1.0", []string{"uuid-1", "uuid-2"}, nil)
+	require.NoError(t, err)
+	require.Len(t, assigned, 2)
+	assigned, err = s.SetUpdateName("main", "v2.0", []string{"uuid-3"}, nil)
+	require.NoError(t, err)
+	require.Len(t, assigned, 1)
+
+	// Assign uuid-4 to v1.0 then delete it: deleted devices must not be counted.
+	assigned, err = s.SetUpdateName("main", "v1.0", []string{"uuid-4"}, nil)
+	require.NoError(t, err)
+	require.Len(t, assigned, 1)
+	d, err := s.DeviceGet("uuid-4")
+	require.NoError(t, err)
+	require.NoError(t, d.Delete())
+
+	updates, err := s.ListUpdates("main")
+	require.NoError(t, err)
+	require.Len(t, updates["main"], 2)
+
+	counts := map[string]int{}
+	for _, u := range updates["main"] {
+		counts[u.Name] = u.DeviceCount
+	}
+	assert.Equal(t, 2, counts["v1.0"], "v1.0 should count only its two non-deleted devices")
+	assert.Equal(t, 1, counts["v2.0"], "v2.0 should count its single assigned device")
+
+	// An update with no assigned devices reports a count of zero.
+	all, err := s.ListUpdates("")
+	require.NoError(t, err)
+	require.Len(t, all["dev"], 1)
+	assert.Equal(t, "v1.0", all["dev"][0].Name)
+	assert.Equal(t, 0, all["dev"][0].DeviceCount)
 }

--- a/storage/api/api_storage_update_test.go
+++ b/storage/api/api_storage_update_test.go
@@ -5,6 +5,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -126,4 +128,68 @@ func TestListUpdatesDeviceCount(t *testing.T) {
 	require.Len(t, all["dev"], 1)
 	assert.Equal(t, "v1.0", all["dev"][0].Name)
 	assert.Equal(t, 0, all["dev"][0].DeviceCount)
+}
+
+func TestDeleteUpdate(t *testing.T) {
+	tmpdir := t.TempDir()
+	dbFile := filepath.Join(tmpdir, "sql.db")
+	db, err := storage.NewDb(dbFile)
+	require.NoError(t, err)
+	fs, err := storage.NewFs(tmpdir)
+	require.NoError(t, err)
+
+	s, err := NewStorage(db, fs)
+	require.NoError(t, err)
+
+	dg, err := gateway.NewStorage(db, fs)
+	require.NoError(t, err)
+
+	// Deleting a non-existent update (unknown tag) returns ErrNotExist.
+	err = s.DeleteUpdate("main", "v1.0")
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	// Seed an update with an on-disk directory.
+	require.NoError(t, s.InsertUpdate("main", "v1.0", "tester"))
+	require.NoError(t, s.fs.Updates.Tuf.WriteFile("main", "v1.0", storage.TufTargetsFile, "{}"))
+
+	// Deleting a non-existent name within an existing tag returns ErrNotExist.
+	err = s.DeleteUpdate("main", "v2.0")
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	// An update with an assigned device cannot be deleted.
+	d, err := dg.DeviceCreate("uuid-1", "pubkey-1")
+	require.NoError(t, err)
+	require.NoError(t, d.CheckIn("target", "main", "hash", ""))
+	assigned, err := s.SetUpdateName("main", "v1.0", []string{"uuid-1"}, nil)
+	require.NoError(t, err)
+	require.Len(t, assigned, 1)
+
+	err = s.DeleteUpdate("main", "v1.0")
+	require.ErrorIs(t, err, ErrUpdateInUse)
+
+	// The update and its files still exist after a refused delete.
+	updates, err := s.ListUpdates("main")
+	require.NoError(t, err)
+	require.Len(t, updates["main"], 1)
+	_, err = s.fs.Updates.Tuf.ReadFile("main", "v1.0", storage.TufTargetsFile)
+	require.NoError(t, err)
+
+	// Once no non-deleted device is assigned, the update can be deleted.
+	dev, err := s.DeviceGet("uuid-1")
+	require.NoError(t, err)
+	require.NoError(t, dev.Delete())
+	require.NoError(t, s.DeleteUpdate("main", "v1.0"))
+
+	// The database row is gone.
+	updates, err = s.ListUpdates("main")
+	require.NoError(t, err)
+	require.Empty(t, updates["main"])
+
+	// The on-disk directory is gone.
+	_, err = s.fs.Updates.Tuf.ReadFile("main", "v1.0", storage.TufTargetsFile)
+	require.True(t, errors.Is(err, os.ErrNotExist), "expected update files to be removed, got %v", err)
+
+	// Deleting an already-deleted update returns ErrNotExist.
+	err = s.DeleteUpdate("main", "v1.0")
+	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/storage/db.go
+++ b/storage/db.go
@@ -20,6 +20,7 @@ type DbHandle struct {
 
 var (
 	ErrDbConstraintUnique = sqllite.ErrConstraintUnique
+	ErrUpdateInUse        = errors.New("update is referenced by one or more devices")
 )
 
 func IsDbError(err error, code sqllite.ErrNoExtended) bool {
@@ -165,7 +166,22 @@ func createTables(db *sql.DB) error {
 			uploaded_by TEXT NOT NULL DEFAULT "",
 			PRIMARY KEY (tag, name)
 		) WITHOUT ROWID;
+
+		CREATE TRIGGER prevent_delete_update_in_use
+			BEFORE DELETE ON updates
+			FOR EACH ROW
+			WHEN EXISTS (
+				SELECT 1
+				FROM devices
+				WHERE tag = OLD.tag
+				AND update_name = OLD.name
+				AND deleted = 0
+			)
+			BEGIN
+				SELECT RAISE(ABORT, '%s');
+			END;
 	`
+	sqlStmt = fmt.Sprintf(sqlStmt, ErrUpdateInUse.Error())
 	if _, err := db.Exec(sqlStmt); err != nil {
 		return fmt.Errorf("unable to create devices db: %w", err)
 	}

--- a/storage/db_fake.go
+++ b/storage/db_fake.go
@@ -11,6 +11,7 @@ import (
 )
 
 var ErrDbConstraintUnique = errors.New("sqllite.ErrConstraintUnique")
+var ErrUpdateInUse = errors.New("update is referenced by one or more devices")
 
 func IsDbError(err error, code any) bool {
 	return false

--- a/storage/file_updates.go
+++ b/storage/file_updates.go
@@ -22,6 +22,8 @@ type Update struct {
 	Name       string `json:"name"`
 	UploadedAt int64  `json:"uploaded-at"`
 	UploadedBy string `json:"uploaded-by"`
+
+	DeviceCount int `json:"device-count"`
 }
 
 type updatesFsHandleWrap struct {

--- a/storage/file_updates.go
+++ b/storage/file_updates.go
@@ -49,6 +49,19 @@ func (s *updatesFsHandleWrap) init(root string) {
 	s.Logs.category = UpdatesLogsDir
 }
 
+// Delete removes the entire on-disk directory for an update (all categories:
+// tuf, ostree_repo, apps, rollouts, logs). A missing directory is not an error.
+func (s updatesFsHandleWrap) Delete(tag, update string) error {
+	dir := filepath.Join(s.root, tag, update)
+	if err := os.RemoveAll(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("error deleting file storage for update %s/%s: %w", tag, update, err)
+	}
+	return nil
+}
+
 // checkUpdateTargets ensures that the update contains a valid targets.json file by looking for:
 //   - is it valid JSON?
 //   - does it have a target with the given tag

--- a/storage/users/scopes.go
+++ b/storage/users/scopes.go
@@ -31,6 +31,7 @@ const (
 
 	ScopeUpdatesR  = scopeR << scopeShiftUpdates
 	ScopeUpdatesRU = (scopeU | scopeR) << scopeShiftUpdates
+	ScopeUpdatesD  = scopeD << scopeShiftUpdates
 
 	ScopeUsersR  = scopeR << scopeShiftUsers
 	ScopeUsersRU = (scopeU | scopeR) << scopeShiftUsers
@@ -46,6 +47,7 @@ var maskToString = map[Scopes]string{
 
 	ScopeUpdatesR:  "updates:read",
 	ScopeUpdatesRU: "updates:read-update",
+	ScopeUpdatesD:  "updates:delete",
 
 	ScopeUsersR:  "users:read",
 	ScopeUsersRU: "users:read-update",

--- a/storage/users/scopes_test.go
+++ b/storage/users/scopes_test.go
@@ -28,8 +28,14 @@ func TestScopesFromString(t *testing.T) {
 		},
 		{
 			name:    "Nonexistent scope",
-			scopes:  "devices:read,updates:delete",
+			scopes:  "devices:read,updates:create",
 			wantErr: true,
+		},
+		{
+			name:   "Updates delete scope",
+			scopes: "updates:delete",
+			want:   ScopeUpdatesD,
+			has:    []Scopes{ScopeUpdatesD},
 		},
 		{
 			name:   "Handle white space",


### PR DESCRIPTION
@vkhoroz - the last two commits were suggested by Claude code review. The one for atomic/race-free deletes makes things a little more complex. Let me know if you want those included in this patch set or not.

Fixes issue #208 