### PR TITLE
docs: document the fiocli updates upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project also includes a user-facing REST API and Web UI for managing devices
 Follow the [Quick Start](./docs/quick-start.md) guide to get a server running in development mode.
 
 ## Adding updates
-The update server uses content from [Offline Updates](https://docs.foundries.io/96/user-guide/offline-update/offline-update.html)
+The update server uses a content format compatible with [Offline Updates](https://docs.foundries.io/latest/user-guide/offline-update/offline-update.html)
 to serve devices their TUF, OSTree, and Container data. Follow the
 [updates](./docs/updates.md) guide for setting this up.
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -2,29 +2,97 @@
 
 ## Producing and Serving Update Content
 
-The update server uses a specific file hierarchy for serving update
-content:
+Update content is the *exact* contents of what `fioctl targets
+offline-update` produces (an `ostree_repo` and/or an `apps` directory,
+and optionally a `tuf` directory).
+
+### Uploading a Update
+
+The recommended way to publish update content is
+`fiocli updates upload`, which streams a local offline-update
+directory to the server over the API:
 
 ```
- <datadir>/updates/
-                   <ci or prod>/
-                                <device tag>/
-                                             <update>
+  fiocli updates upload <tag> <update-name> <directory>
 ```
 
-The contents of the `update` directory above are the *exact* contents
-of what `fioctl targets offline-update` produces. Let's say we want to
-deploy a CI build to some devices connected to our server.
-The Target is tagged with `main` and is named `intel-corei7-64-lmp-148`.
-The content can be staged on the server by running:
+For example, to upload the offline content produced above and name the
+update `148` under the `main` tag:
 
 ```
-  cd <datadir>
-  mkdir -p updates/ci/main/148
-  fioctl targets offline-update --expires-in-days 180 --tag main intel-corei7-64-lmp-148 ./updates/ci/main/148
+  fioctl targets offline-update --expires-in-days 180 --tag main intel-corei7-64-lmp-148 ./148
+  # If you've enabled TUF on your server, then you should remove the `tuf` 
+  # directory before running fiocli updates upload
+  # rm -rf ./148/tuf
+  fiocli updates upload main 148 ./148
 ```
 
-This update will now show up under the "updates" view in your UI.
+
+The directory is archived, gzip-compressed, and streamed to the server.
+This update will then show up under the "updates" view in your UI.
+
+### Automatic TUF Target Generation
+
+An offline-update directory produced by `fioctl` includes a `tuf`
+directory with signed TUF metadata. Providing that metadata is 
+*optional*: when the uploaded content does not contain a `tuf`
+directory, the server generates a TUF target for the update itself
+(this requires TUF to be enabled on the server).
+
+To build the target, the server *probes* the uploaded content to make a
+best-effort guess about the target's attributes:
+
+* **`ostree-hash`** and **`name`** are read from the ostree repository's
+  ref under `ostree_repo`.
+* **`version`** (AppVersion) is read from `IMAGE_VERSION` in the image's
+  `/usr/lib/os-release`.
+* **`hardware-id`** is read from `primary_ecu_hardware_id` in the image's
+  `/usr/lib/sota/conf.d/40-hardware-id.toml`. If that file is absent, the
+  server falls back to detecting the architecture from the image
+  (`arm64-linux` or `amd64-linux`).
+* **`apps`** are discovered from the `apps` directory layout, mapping
+  each app to its sha256.
+
+Because probing is a best effort, you can override any of these attributes
+with flags, which is also useful when uploading content that has no
+`ostree_repo` (for example, an apps-only update):
+
+```
+  fiocli updates upload main 148 ./148 \
+    --hardware-id intel-corei7-64 \
+    --version 148 \
+    --name intel-corei7-64-lmp-148 \
+    --ostree-hash <sha256> \
+    --apps shellhttpd=<sha256>
+```
+
+> [!NOTE]
+> If you are bundling apps into your updates, probing the
+> ostree image for a default `version` will not be sufficient. Your apps
+> might change from one update to the next while still using the same
+> ostree, so the probed `IMAGE_VERSION` would collide. In that case,
+> supply a distinct `--version` for each update.
+
+> [!NOTE]
+> When the upload does not contain an `ostree_repo` directory,
+> `--hardware-id` is required because it cannot be probed.
+
+### Uploading via API
+
+The upload is a `POST` to `/v1/updates/<tag>/<update>` with the
+gzip-compressed tar archive as the request body. The override attributes
+are passed as query parameters (`version`, `hardware-id`, `name`,
+`ostree-hash`, and `apps` as `name=sha256`). For example:
+
+```
+  curl \
+    -H 'Authorization: Bearer <your token>' \
+    -H 'Content-Type: application/x-tar' \
+    -H 'Content-Encoding: gzip' \
+    -X POST \
+    --data-binary @148.tar.gz \
+    'http://<your server>/v1/updates/main/148?hardware-id=intel-corei7-64'
+```
 
 ## Updating Your Devices
 


### PR DESCRIPTION
Previously the updates guide described staging content directly in the server's data directory, which no longer reflects how updates are published. Uploads now flow through an API, and the server can generate a TUF target by probing the uploaded ostree/apps content when no TUF metadata is supplied.

Rewrite the updates guide to describe the fiocli updates upload command, the automatic TUF target generation and its probing logic, the override flags, and the equivalent API request. Also adjust the top-level README to state the server uses a content format compatible with Offline Updates.