### PR TITLE
seed: extend mock data coverage for local UI testing

### DIFF
--- a/cmd/seed/configs.go
+++ b/cmd/seed/configs.go
@@ -1,0 +1,43 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/foundriesio/update-server/storage/api"
+)
+
+// seedGlobalConfigs saves a factory-wide config and one config per device
+// group, so the Global/Group Configs pages aren't empty on a fresh server.
+// Idempotent: skips any config class that already has history.
+func seedGlobalConfigs(ap *api.Storage) error {
+	if history, err := ap.ReadFactoryConfigHistory(1, false); err != nil {
+		return fmt.Errorf("ReadFactoryConfigHistory: %w", err)
+	} else if len(history) == 0 {
+		const factoryConfig = `{"tag.main":{"Value":"main"}}`
+		if err := ap.SaveFactoryConfig(factoryConfig, "noauth-fake-user", "seed"); err != nil {
+			return fmt.Errorf("SaveFactoryConfig: %w", err)
+		}
+		log.Printf("create factory config")
+	} else {
+		log.Printf("skip  factory config (already exists)")
+	}
+
+	for _, group := range groups {
+		if history, err := ap.ReadGroupConfigHistory(group, 1, false); err != nil {
+			return fmt.Errorf("ReadGroupConfigHistory(%s): %w", group, err)
+		} else if len(history) > 0 {
+			log.Printf("skip  group config %s (already exists)", group)
+			continue
+		}
+		groupConfig := fmt.Sprintf(`{"group.name":{"Value":"%s"}}`, group)
+		if err := ap.SaveGroupConfig(group, groupConfig, "noauth-fake-user", "seed"); err != nil {
+			return fmt.Errorf("SaveGroupConfig(%s): %w", group, err)
+		}
+		log.Printf("create group config %s", group)
+	}
+	return nil
+}

--- a/cmd/seed/device_extras.go
+++ b/cmd/seed/device_extras.go
@@ -1,0 +1,117 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/foundriesio/update-server/storage"
+	"github.com/foundriesio/update-server/storage/api"
+	"github.com/foundriesio/update-server/storage/gateway"
+)
+
+// seedDeviceConfigHistory saves a few device config revisions so the config
+// history page has more than a single entry to render. Config content is
+// stored as JSON-encoded {filename: ConfigFile}, keyed by the sota override
+// filename devices actually read (storage.ConfigSotaOverride).
+func seedDeviceConfigHistory(ap *api.Storage, uuid string) error {
+	revisions := []struct{ pacman, reason string }{
+		{"ostree", "initial config"},
+		{"ostree+compose_apps", "enable compose apps"},
+		{"ostree+compose_apps,restorable", "enable restorable compose apps"},
+	}
+	for _, rev := range revisions {
+		tomlConfig := fmt.Sprintf(`[device]
+  uuid = "%s"
+  tag = "main"
+
+[pacman]
+  type = "%s"
+`, uuid, rev.pacman)
+		files := map[string]api.ConfigFile{
+			storage.ConfigSotaOverride: {Value: tomlConfig},
+		}
+		content, err := json.Marshal(files)
+		if err != nil {
+			return fmt.Errorf("marshal device config for %s: %w", uuid, err)
+		}
+		if err := ap.SaveDeviceConfig(uuid, string(content), "noauth-fake-user", rev.reason); err != nil {
+			return fmt.Errorf("SaveDeviceConfig(%s): %w", uuid, err)
+		}
+	}
+	return nil
+}
+
+// seedDeviceAppsStates saves a fake apps-states snapshot for the device's
+// "Apps States" page.
+func seedDeviceAppsStates(d *gateway.Device, i int) error {
+	content := fmt.Sprintf(`{
+  "deviceTime": "2026-07-23T12:00:00Z",
+  "ostree": "%064x",
+  "apps": {
+    "shellhttpd": {
+      "uri": "hub.foundries.io/local-factory/shellhttpd@sha256:%064x",
+      "state": "running",
+      "services": [
+        {"name": "shellhttpd", "hash": "%064x", "health": "healthy", "image": "shellhttpd:latest", "state": "running", "status": "Up 2 hours"}
+      ]
+    },
+    "nginx": {
+      "uri": "hub.foundries.io/local-factory/nginx@sha256:%064x",
+      "state": "running",
+      "services": [
+        {"name": "nginx", "hash": "%064x", "health": "healthy", "image": "nginx:latest", "state": "running", "status": "Up 2 hours"}
+      ]
+    }
+  }
+}`, i*0xdeadbeef, i*31, i*37, i*41, i*43)
+	return d.SaveAppsStates(content)
+}
+
+// seedDeviceAppliedConfigs saves a fake merged applied-config envelope for
+// the device's "Applied Configs" page.
+func seedDeviceAppliedConfigs(d *gateway.Device) error {
+	cfg := gateway.AppliedConfigs{
+		Files: map[string]gateway.ConfigFile{
+			"z-50-fioctl.toml": {Value: "[pacman]\n  type = \"ostree+compose_apps\"\n"},
+		},
+		AppliedAt: time.Now().Unix(),
+	}
+	cfg.AuditTrail[2].CreatedBy = "noauth-fake-user"
+	cfg.AuditTrail[2].Reason = "seed"
+	return d.SaveAppliedConfigs(cfg)
+}
+
+// seedDeviceTests creates a couple of fake fiotest results (one passed, one
+// failed) for the device's Tests tab, including one stored artifact.
+func seedDeviceTests(d *gateway.Device, targetName string, i int) error {
+	tests := []struct {
+		name, status, details string
+	}{
+		{"smoke-test", "PASSED", ""},
+		{"integration-test", "FAILED", "assertion failed: expected 200, got 500"},
+	}
+	for j, tc := range tests {
+		testId := fmt.Sprintf("seed-test-%05d-%02d", i, j)
+		if err := d.TestCreate(targetName, tc.name, testId); err != nil {
+			return fmt.Errorf("TestCreate(%s): %w", testId, err)
+		}
+		results := []storage.TargetTestResult{
+			{Name: "boot-time", Status: "PASSED", Details: "", Metrics: map[string]float64{"seconds": 4.2}},
+		}
+		if err := d.TestComplete(testId, tc.status, tc.details, results); err != nil {
+			return fmt.Errorf("TestComplete(%s): %w", testId, err)
+		}
+		if j == 0 {
+			artifact := []byte("seed test log line 1\nseed test log line 2\n")
+			if err := d.TestStoreArtifact(testId, "test.log", bytes.NewReader(artifact)); err != nil {
+				return fmt.Errorf("TestStoreArtifact(%s): %w", testId, err)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/seed/events.go
+++ b/cmd/seed/events.go
@@ -1,0 +1,60 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/foundriesio/update-server/storage"
+	"github.com/foundriesio/update-server/storage/gateway"
+)
+
+// seedRolloutEvents sends a fake sequence of update-progress events for each
+// device in uuids, so the device's update-history page and the rollout tail
+// log show real content instead of being empty.
+func seedRolloutEvents(gw *gateway.Storage, updateName string, uuids []string) error {
+	stages := []string{
+		"EcuDownloadStarted",
+		"EcuDownloadCompleted",
+		"EcuInstallationStarted",
+		"EcuInstallationApplied",
+		"EcuInstallationCompleted",
+	}
+
+	for _, uuid := range uuids {
+		d, err := gw.DeviceGet(uuid)
+		if err != nil {
+			return fmt.Errorf("DeviceGet(%s): %w", uuid, err)
+		}
+		if d == nil {
+			continue
+		}
+
+		targetName := fmt.Sprintf("intel-corei7-64-lmp-%s", updateName)
+		corrId := fmt.Sprintf("seed-rollout-%s", uuid)
+		now := time.Now().UTC()
+
+		events := make([]storage.DeviceUpdateEvent, 0, len(stages))
+		for i, stage := range stages {
+			success := true
+			events = append(events, storage.DeviceUpdateEvent{
+				Id:         fmt.Sprintf("%s-%d", corrId, i),
+				DeviceTime: now.Add(time.Duration(i) * time.Second).Format(time.RFC3339),
+				Event: storage.DeviceEvent{
+					CorrelationId: corrId,
+					Ecu:           "seed-ecu",
+					Success:       &success,
+					TargetName:    targetName,
+					Version:       updateName,
+				},
+				EventType: storage.DeviceEventType{Id: stage, Version: 1},
+			})
+		}
+		if err := d.ProcessEvents(events); err != nil {
+			return fmt.Errorf("ProcessEvents(%s): %w", uuid, err)
+		}
+	}
+	return nil
+}

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/api"
 	"github.com/foundriesio/update-server/storage/gateway"
+	"github.com/foundriesio/update-server/storage/users"
 )
 
 // dummyPubKey is a hardcoded RSA public key PEM block. It is only displayed in
@@ -28,8 +29,10 @@ LQIDAQAB
 
 var groups = []string{"alpha", "beta", "gamma", "delta", "epsilon"}
 
-// openStorage opens the filesystem, database, gateway, and API storage handles
-// for the given datadir. It is shared by seedDevices and seedUpdates.
+// openStorage opens the filesystem, database, gateway, and API storage
+// handles for the given datadir. It is shared by all seed* functions except
+// seedUsers, which needs the HMAC secret created by `auth-init` and so opens
+// its own users.Storage handle.
 func openStorage(datadir string) (*storage.FsHandle, *api.Storage, *gateway.Storage, error) {
 	fs, err := storage.NewFs(datadir)
 	if err != nil {
@@ -50,6 +53,21 @@ func openStorage(datadir string) (*storage.FsHandle, *api.Storage, *gateway.Stor
 	return fs, ap, gw, nil
 }
 
+// openUserStorage opens the user storage handle for the given datadir. It
+// requires the HMAC secret created by `fioserver auth-init`.
+func openUserStorage(datadir string) (*users.Storage, error) {
+	fs, err := storage.NewFs(datadir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load filesystem: %w", err)
+	}
+	db, err := storage.NewDb(fs.Config.DbFile())
+	if err != nil {
+		return nil, fmt.Errorf("failed to load database: %w", err)
+	}
+	return users.NewStorage(db, fs)
+}
+
+// seedDevices creates numDevices mock devices.
 func seedDevices(datadir string, numDevices int) error {
 	_, ap, gw, err := openStorage(datadir)
 	if err != nil {
@@ -68,7 +86,8 @@ func seedDevices(datadir string, numDevices int) error {
 			return fmt.Errorf("DeviceGet(%s): %w", uuid, err)
 		}
 		var d *gateway.Device
-		if existing != nil {
+		isNew := existing == nil
+		if !isNew {
 			log.Printf("skip  %s (already exists)", uuid)
 			skipped++
 			d = existing
@@ -109,15 +128,19 @@ func seedDevices(datadir string, numDevices int) error {
 			return fmt.Errorf("PatchDeviceLabels(%s): %w", uuid, err)
 		}
 
-		tomlConfig := fmt.Sprintf(`[device]
-  uuid = "%s"
-  tag = "main"
-
-[pacman]
-  type = "ostree+compose_apps"
-`, uuid)
-		if err := ap.SaveDeviceConfig(uuid, tomlConfig, "noauth-fake-user", "seed"); err != nil {
-			return fmt.Errorf("SaveDeviceConfig(%s): %w", uuid, err)
+		if isNew {
+			if err := seedDeviceConfigHistory(ap, uuid); err != nil {
+				return err
+			}
+			if err := seedDeviceAppsStates(d, i); err != nil {
+				return fmt.Errorf("SaveAppsStates(%s): %w", uuid, err)
+			}
+			if err := seedDeviceAppliedConfigs(d); err != nil {
+				return fmt.Errorf("SaveAppliedConfigs(%s): %w", uuid, err)
+			}
+			if err := seedDeviceTests(d, targetName, i); err != nil {
+				return fmt.Errorf("seed tests(%s): %w", uuid, err)
+			}
 		}
 	}
 
@@ -141,12 +164,25 @@ func main() {
 		log.Fatalf("seed devices failed: %v", err)
 	}
 
+	fs, ap, gw, err := openStorage(*datadir)
+	if err != nil {
+		log.Fatalf("seed: open storage: %v", err)
+	}
+
+	if err := seedGlobalConfigs(ap); err != nil {
+		log.Fatalf("seed global/group configs failed: %v", err)
+	}
+
+	us, err := openUserStorage(*datadir)
+	if err != nil {
+		log.Fatalf("seed users: open storage: %v", err)
+	}
+	if err := seedUsers(us); err != nil {
+		log.Fatalf("seed users failed: %v", err)
+	}
+
 	if *numUpdates > 0 {
-		fs, ap, _, err := openStorage(*datadir)
-		if err != nil {
-			log.Fatalf("seed updates: open storage: %v", err)
-		}
-		if err := seedUpdates(fs, ap, *numUpdates); err != nil {
+		if err := seedUpdates(fs, ap, gw, *numUpdates); err != nil {
 			log.Fatalf("seed updates failed: %v", err)
 		}
 	}

--- a/cmd/seed/main_test.go
+++ b/cmd/seed/main_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/foundriesio/update-server/storage"
+	"github.com/foundriesio/update-server/storage/api"
 	"github.com/foundriesio/update-server/storage/gateway"
+	"github.com/foundriesio/update-server/storage/users"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,15 +19,60 @@ func TestSeed(t *testing.T) {
 	err := seedDevices(datadir, 3)
 	require.NoError(t, err)
 
-	// Verify the first device is retrievable via gateway DeviceGet.
 	fs, err := storage.NewFs(datadir)
 	require.NoError(t, err)
+	require.NoError(t, fs.Auth.InitHmacSecret())
 	db, err := storage.NewDb(fs.Config.DbFile())
 	require.NoError(t, err)
 	gw, err := gateway.NewStorage(db, fs)
+	require.NoError(t, err)
+	ap, err := api.NewStorage(db, fs)
 	require.NoError(t, err)
 
 	d, err := gw.DeviceGet("seed-device-00001")
 	require.NoError(t, err)
 	require.NotNil(t, d, "expected seed-device-00001 to be present in the DB")
+
+	// Verify device extras: config history, apps-states, applied-configs, tests.
+	history, err := ap.ReadDeviceConfigHistory("seed-device-00001", 10, true)
+	require.NoError(t, err)
+	require.Len(t, history, 3, "expected 3 device config revisions")
+	require.Contains(t, history[0].RawFiles, storage.ConfigSotaOverride,
+		"device config must be valid JSON keyed by the sota override filename, not raw TOML")
+
+	apiDevice, err := ap.DeviceGet("seed-device-00001")
+	require.NoError(t, err)
+	require.NotNil(t, apiDevice)
+
+	states, err := apiDevice.AppsStates()
+	require.NoError(t, err)
+	require.NotEmpty(t, states, "expected apps-states to be seeded")
+
+	applied, err := ap.ReadAppliedConfigs("seed-device-00001")
+	require.NoError(t, err)
+	require.NotNil(t, applied, "expected applied configs to be seeded")
+	require.Greater(t, applied.AppliedAt, int64(0), "expected AppliedAt to be set")
+
+	tests, err := apiDevice.GetTests()
+	require.NoError(t, err)
+	require.Len(t, tests, 2, "expected 2 seeded test results")
+
+	// Verify global/group configs and users, called the same way main() calls them.
+	require.NoError(t, seedGlobalConfigs(ap))
+	factoryHistory, err := ap.ReadFactoryConfigHistory(1, false)
+	require.NoError(t, err)
+	require.Len(t, factoryHistory, 1, "expected factory config to be seeded")
+
+	us, err := users.NewStorage(db, fs)
+	require.NoError(t, err)
+	require.NoError(t, seedUsers(us))
+	u, err := us.Get("seed-operator")
+	require.NoError(t, err)
+	require.NotNil(t, u, "expected seed-operator user to be seeded")
+
+	// Verify idempotency: seeding again does not error or duplicate config history.
+	require.NoError(t, seedDevices(datadir, 3))
+	history, err = ap.ReadDeviceConfigHistory("seed-device-00001", 10, false)
+	require.NoError(t, err)
+	require.Len(t, history, 3, "re-seeding must not duplicate device config history")
 }

--- a/cmd/seed/updates.go
+++ b/cmd/seed/updates.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/api"
+	"github.com/foundriesio/update-server/storage/gateway"
 )
 
 // updateRegistered reports whether (tag, name) is already in the updates table.
@@ -196,8 +197,10 @@ func rootJSON(i int, expires string) string {
 }
 
 // seedUpdates creates `count` fake update entries (TUF metadata + token dirs +
-// one rollout each) under <datadir>/updates/main/.
-func seedUpdates(fs *storage.FsHandle, apiStorage *api.Storage, count int) error {
+// one rollout each) under <datadir>/updates/main/. The first update's rollout
+// is committed against the "alpha" group and fed a fake device-event history,
+// so the rollout tail log and per-device update pages aren't empty.
+func seedUpdates(fs *storage.FsHandle, apiStorage *api.Storage, gw *gateway.Storage, count int) error {
 	const tag = "main"
 	const baseVersion = 148
 
@@ -278,6 +281,23 @@ func seedUpdates(fs *storage.FsHandle, apiStorage *api.Storage, count int) error
 				Groups: []string{"alpha"},
 			}); err != nil {
 				return fmt.Errorf("CreateRollout for %s/%s: %w", tag, name, err)
+			}
+
+			// Only the first update's rollout is committed against the "alpha"
+			// group, so exactly one update gets a full device-event history.
+			if i == 0 {
+				if err := apiStorage.CommitRollout(tag, name, rolloutName, api.Rollout{
+					Groups: []string{"alpha"},
+				}); err != nil {
+					return fmt.Errorf("CommitRollout for %s/%s: %w", tag, name, err)
+				}
+				rollout, err := apiStorage.GetRollout(tag, name, rolloutName)
+				if err != nil {
+					return fmt.Errorf("GetRollout for %s/%s: %w", tag, name, err)
+				}
+				if err := seedRolloutEvents(gw, name, rollout.Effect); err != nil {
+					return fmt.Errorf("seed rollout events for %s/%s: %w", tag, name, err)
+				}
 			}
 			log.Printf("create update %s/%s + rollout %s", tag, name, rolloutName)
 			created++

--- a/cmd/seed/updates_test.go
+++ b/cmd/seed/updates_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/api"
+	"github.com/foundriesio/update-server/storage/gateway"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,8 +22,14 @@ func TestSeedUpdates(t *testing.T) {
 	require.NoError(t, err)
 	apiStorage, err := api.NewStorage(db, fs)
 	require.NoError(t, err)
+	gw, err := gateway.NewStorage(db, fs)
+	require.NoError(t, err)
 
-	err = seedUpdates(fs, apiStorage, 2)
+	// Seed one alpha-group device so the first update's rollout has something
+	// to commit against and generate device events for.
+	require.NoError(t, seedDevices(datadir, 1))
+
+	err = seedUpdates(fs, apiStorage, gw, 2)
 	require.NoError(t, err)
 
 	// Verify both updates are listed.
@@ -67,12 +74,28 @@ func TestSeedUpdates(t *testing.T) {
 	require.Contains(t, target.Custom.Tags, "main", "target tags must include 'main'")
 	require.Equal(t, "148", target.Custom.Version, "target version must be the numeric string '148'")
 
-	// Verify rollout was created.
+	// Verify rollout was created and committed for update 148.
 	rollouts, err := apiStorage.ListRollouts("main", "148")
 	require.NoError(t, err)
 	require.Contains(t, rollouts, "seed-rollout", "expected seed-rollout to be created for update 148")
 
-	// Verify idempotency: seed again and ensure we get 0 created, 2 skipped.
-	err = seedUpdates(fs, apiStorage, 2)
+	rollout, err := apiStorage.GetRollout("main", "148", "seed-rollout")
+	require.NoError(t, err)
+	require.True(t, rollout.Commit, "expected seed-rollout for update 148 to be committed")
+	require.Contains(t, rollout.Effect, "seed-device-00001", "expected alpha-group device to be assigned the update")
+
+	// Verify the device received a fake update-event history.
+	apiDevice, err := apiStorage.DeviceGet("seed-device-00001")
+	require.NoError(t, err)
+	require.NotNil(t, apiDevice)
+	updateIds, err := apiDevice.Updates()
+	require.NoError(t, err)
+	require.NotEmpty(t, updateIds, "expected device to have update-event history")
+	events, err := apiDevice.Events(updateIds[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "expected device update events to be seeded")
+
+	// Verify idempotency: seed again and ensure it doesn't fail or double-commit.
+	err = seedUpdates(fs, apiStorage, gw, 2)
 	require.NoError(t, err, "second seedUpdates call should not fail (idempotent)")
 }

--- a/cmd/seed/users.go
+++ b/cmd/seed/users.go
@@ -1,0 +1,57 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/foundriesio/update-server/auth"
+	"github.com/foundriesio/update-server/storage/users"
+)
+
+// seedUsers creates a couple of extra local-auth users with varied scopes,
+// plus an API token for one of them, so the Users and Settings pages have
+// more to show than the single bootstrap admin. Idempotent: skips any
+// username that already exists.
+func seedUsers(userStorage *users.Storage) error {
+	seedAccounts := []struct {
+		username string
+		scopes   users.Scopes
+	}{
+		{"seed-viewer", users.ScopeDevicesR | users.ScopeUpdatesR},
+		{"seed-operator", users.ScopeDevicesRU | users.ScopeUpdatesRU | users.ScopeUsersR},
+	}
+
+	for _, acct := range seedAccounts {
+		if existing, err := userStorage.Get(acct.username); err != nil {
+			return fmt.Errorf("Get(%s): %w", acct.username, err)
+		} else if existing != nil {
+			log.Printf("skip  user %s (already exists)", acct.username)
+			continue
+		}
+
+		password, err := auth.PasswordHash("seed-password")
+		if err != nil {
+			return fmt.Errorf("PasswordHash(%s): %w", acct.username, err)
+		}
+		u := &users.User{
+			Username:      acct.username,
+			Password:      password,
+			AllowedScopes: acct.scopes,
+		}
+		if err := userStorage.Create(u); err != nil {
+			return fmt.Errorf("Create(%s): %w", acct.username, err)
+		}
+		log.Printf("create user %s", acct.username)
+
+		if acct.username == "seed-operator" {
+			const oneYear = 365 * 24 * 60 * 60
+			if _, err := u.GenerateToken("seed API token", u.CreatedAt+oneYear, users.ScopeDevicesR); err != nil {
+				return fmt.Errorf("GenerateToken(%s): %w", acct.username, err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add device test results, apps-states, applied configs, extra config
history revisions, factory/group configs, extra users with API
tokens, and a committed rollout with device-event history, so pages
that previously rendered empty on a fresh run-local.sh server now
show realistic data.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Milo Casagrande <mcasagra@qti.qualcomm.com>
