### PR TITLE
docs: add guide for building an update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ The project also includes a user-facing REST API and Web UI for managing devices
 Follow the [Quick Start](./docs/quick-start.md) guide to get a server running in development mode.
 
 ## Adding updates
-The update server uses a content format compatible with [Offline Updates](https://docs.foundries.io/latest/user-guide/offline-update/offline-update.html)
-to serve devices their TUF, OSTree, and Container data. Follow the
+The update server uses a content format compatible with [Offline Updates](https://docs.foundries.io/96/user-guide/offline-update/offline-update.html)
+to serve devices their TUF, OSTree, and Container data. Before uploading,
+see [How to build an Update](./docs/build-an-update.md) for producing that
+content in the first place. Then follow the
 [updates](./docs/updates.md) guide for setting this up.
 
 ## API access

--- a/docs/build-an-update.md
+++ b/docs/build-an-update.md
@@ -1,0 +1,143 @@
+# How to Build an Update
+
+Producing an update for this server is a three-step process:
+
+1. Build a platform (OS) image — this produces an `ostree_repo`.
+2. Build your containers and compose app(s).
+3. Combine the `ostree_repo` and your app(s) into an offline-update
+   directory, ready to be uploaded per the [updates](./updates.md) guide.
+
+## Platform Build
+
+### Using an Existing FoundriesFactory
+
+> See [Building From Source](https://docs.foundries.io/97/user-guide/lmp-customization/linux-building.html)
+> for the full walkthrough. This section only covers the parts specific to
+> producing update content for this server.
+
+```
+  repo init -u https://source.foundries.io/factories/<factory-name>/lmp-manifest.git -b main -m <factory-name>.xml
+  repo sync
+  MACHINE=<machine-name> source setup-environment [BUILDDIR]
+```
+
+Before building, set `H_BUILD` in `conf/local.conf` to a number that
+identifies this build:
+
+```
+  echo 'H_BUILD = "148"' >> conf/local.conf
+```
+
+> [!NOTE]
+> `H_BUILD` is just a build number for the platform image — pick
+> any incrementing value you like. It does not need to match or correlate
+> with your app build numbers; the platform and app builds are versioned
+> independently and only get tied together in the [Combine](#combine) step.
+> The first time you build, its recommended to set H_BUILD to your latest
+> FoundriesFactory target number and add 1.
+
+Now build:
+
+```
+  bitbake lmp-factory-image
+```
+
+Once the build finishes, your `ostree_repo` is under:
+
+```
+  deploy/images/<machine-name>/ostree_repo
+```
+
+That's the directory referenced as `ostree_repo` throughout the
+[updates](./updates.md) guide.
+
+### Without FoundriesFactory (meta-foundries + QLI)
+
+<!-- TODO: document building the platform without a FoundriesFactory.-->
+
+## Build Apps
+
+### Build and Push Container Images
+
+Build each container image and push it to a registry, capturing the
+digest of the pushed image so it can be pinned into the compose app:
+
+```
+  docker buildx build --push -t <registry>/<image-name>:<tag> .
+```
+
+The push output (or `docker/build-push-action`'s `digest` output, if
+you're doing this via CI) gives you a `sha256` for the image — you will pin
+that in the next step rather than trusting a mutable tag.
+
+### Build and Publish the Compose App
+
+Write a `docker-compose.yml` referencing your image(s). Publishing it
+with `composectl publish` produces the sha256 for the app itself:
+
+```
+  composectl publish -d app.hash \
+    --pinned-images <registry>/<image-name>@sha256:<image-digest> \
+    <registry>/<app-name>-app:<tag> amd64,arm64
+```
+
+* `-d app.hash` writes the app's own digest to the file `app.hash`.
+* `--pinned-images` takes a comma-separated list of image digest URIs and
+  rewrites `docker-compose.yml`'s image references to match, so you do not
+  need to hand-edit digests into the compose file yourself. Omit it if
+  your compose file already pins images directly.
+* The trailing argument is the comma-separated list of architectures to
+  publish for.
+
+The app's own sha256 is now in `app.hash`, giving you an app URI of
+`<registry>/<app-name>-app@sha256:<contents of app.hash>`.
+
+You can also refer to the [example GitHub Workflow](./gh-workflow-example.yml).
+
+### Get the App to the Update Server
+
+> [!NOTE]
+> the update server never needs access to the registry your apps
+> or containers were pushed to. It only needs the resulting app name and
+> sha256.
+
+Pass your app directly at upload time with `--apps <name>=<sha256>` (see
+[Combine](#combine) below) — the simplest option when you already have the
+app's sha256 (the contents of `app.hash` from step 2) sitting in CI.
+
+Alternatively, lay it out in an `apps` directory by pulling the published app with
+`composectl pull`:
+
+```
+  composectl pull -i ./148/apps -s ./148/apps \
+    <registry>/<app-name>-app@sha256:<contents of app.hash>
+```
+
+This produces the `apps/apps/<app-name>/<sha256>/` layout that
+`fiocli updates upload` probes automatically — the same layout
+`fioctl targets offline-update` produces for apps built through
+FoundriesFactory.
+
+## Combine
+
+With an `ostree_repo` from the platform build and one or more app
+name/sha256 pairs from the app build run:
+```
+  fiocli updates upload main 148 ./148  --version 148 \
+```
+
+> [!NOTE] if your apps change between updates that share the same
+> ostree build, do not rely on the probed `version` (from `IMAGE_VERSION`,
+> which comes from your platform's `H_BUILD`) — it will collide. Pass a
+> distinct `--version` for each update instead, as described in
+> [updates.md](./updates.md#automatic-tuf-target-generation).
+
+One common approach to creating an app version:
+ * Take the `H_BUILD` value (`ostree --repo=148/ostree_repo repo  <ref> cat /etc/os-release`) and multiply by 1000
+ * Add your apps build number.
+
+For this example with platform build 148 and say, apps version 42,
+the version could become 148042.
+
+Once combined, follow the rest of the [updates](./updates.md) guide to
+upload and roll out the result.

--- a/docs/gh-workflow-example.yml
+++ b/docs/gh-workflow-example.yml
@@ -1,0 +1,192 @@
+name: gh-action-exampe
+
+on:
+  workflow_call:
+    inputs:
+      imgtag:
+        required: true
+        type: string
+      push:
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # build-images is a matrix job to build multiple container images in parallel. 
+  # Each image is built and pushed to ghcr.io.
+  build-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker_dir: [shellhttpd, dg-satellite]
+
+    # The pinned (digest) URI of each image is published as an artifact rather
+    # than a matrix job output, since matrix job outputs are last-writer-wins.
+    outputs:
+      image_tag: ${{ steps.tag.outputs.short_sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set short git commit SHA
+        id: tag
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "short_sha=$calculatedSha" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          push: ${{ inputs.push }}
+          platforms: linux/amd64,linux/arm64
+          context: "{{ defaultContext }}:${{ matrix.docker_dir }}"
+          tags: |
+            ghcr.io/<your-org>/${{ matrix.docker_dir }}:${{ steps.tag.outputs.short_sha }}
+            ghcr.io/<your-org>/${{ matrix.docker_dir }}:${{ inputs.imgtag }}
+      - name: Save pinned image URI
+        run: |
+          mkdir -p pinned
+          echo "ghcr.io/<your-org>/${{ matrix.docker_dir }}@${{ steps.docker_build.outputs.digest }}" > "pinned/${{ matrix.docker_dir }}"
+      - name: Upload pinned image URI
+        uses: actions/upload-artifact@v4
+        with:
+          name: pinned-${{ matrix.docker_dir }}
+          path: pinned
+          if-no-files-found: error
+  
+  # Generate the build number exactly once so every app shares the same value.
+  # Only bump it once the images have built successfully.
+  version:
+    needs: build-images
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.buildnumber.outputs.build_number }}
+    steps:
+      - name: Generate build number
+        id: buildnumber
+        if: github.event_name == 'push'
+        uses: onyxmueller/build-tag-number@v1
+        with:
+          token: ${{ secrets.github_token }}
+
+
+  # One matrix leg per app. Apps and images are independent: an app may pin
+  # zero, one, or many images, and image names need not match the app name.
+  # The `images` field is a space-separated list of image names (from the
+  # build-images matrix) whose pinned digests should be passed to the app.
+  build-app:
+    needs: [version, build-images]
+    runs-on: ubuntu-latest
+    container:
+      image: foundries/lmp-app-tools
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: shellhttpd
+            images: shellhttpd
+            platforms: amd64,arm64
+          - app: dg-satellite
+            images: dg-satellite
+            platforms: amd64,arm64
+          - app: homeassistant
+            platforms: amd64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download pinned image URIs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pinned-*
+          path: pinned
+          merge-multiple: true
+
+      - name: Build and push app
+        id: build
+        working-directory: ${{ matrix.app }}
+        run: |
+          set -x
+          tag="${{ needs.build-images.outputs.image_tag }}"
+          bn="${{ needs.version.outputs.build_number || '' }}"
+          if [ -n "${bn}" ] ; then
+            tag="${bn}_${tag}"
+          fi
+          pinned_args=""
+          uris=""
+          for img in ${{ matrix.images }} ; do
+            uri="$(cat ../pinned/${img})"
+            uris="${uris:+${uris},}${uri}"
+          done
+          if [ -n "${uris}" ] ; then
+            pinned_args="--pinned-images ${uris}"
+          fi
+          composectl publish -d app.hash ${pinned_args} ghcr.io/<your-org>/${{ matrix.app }}-app:${tag} ${{ matrix.platforms }}
+          uri="ghcr.io/<your-org>/${{ matrix.app }}-app@$(cat app.hash)"
+          mkdir -p ../app-uris
+          echo "${uri}" > "../app-uris/${{ matrix.app }}"
+
+      - name: Upload app URI
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-uri-${{ matrix.app }}
+          path: app-uris
+          if-no-files-found: error
+
+  # Pull every published app into a single store, sequentially, so the offline
+  # bundle's store index stays consistent, then upload it as one artifact.
+  assemble-offline:
+    needs: [version, build-app]
+    runs-on: ubuntu-latest
+    container:
+      image: foundries/lmp-app-tools
+    steps:
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download app URIs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: app-uri-*
+          path: app-uris
+          merge-multiple: true
+
+      - name: Create offline update directory
+        run: |
+          set -x
+          mkdir -p update/apps
+          echo "${{ needs.version.outputs.build_number || 'local' }}" > update/apps/version
+          for f in app-uris/* ; do
+            uri="$(cat "${f}")"
+            composectl pull -i update/apps -s update/apps "${uri}"
+          done
+
+      - name: Save content for offline use
+        uses: actions/upload-artifact@v4
+        with:
+          name: offline-apps
+          path: update
+          if-no-files-found: error

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -4,7 +4,9 @@
 
 Update content is the *exact* contents of what `fioctl targets
 offline-update` produces (an `ostree_repo` and/or an `apps` directory,
-and optionally a `tuf` directory).
+and optionally a `tuf` directory). See
+[How to build an Update](./build-an-update.md) for producing that content
+in the first place.
 
 ### Uploading a Update
 


### PR DESCRIPTION
docs/updates.md only covers uploading an already-built offline-update directory to the server; it never explains how to produce that directory. Add docs/build-an-update.md, which walks through building the platform image (including setting H_BUILD and locating the resulting ostree_repo), building containers/compose apps, and combining the two into content ready for upload. Cross-link it from README.md and docs/updates.md.