### PR TITLE
Updates report

### DIFF
--- a/cli/api/updates.go
+++ b/cli/api/updates.go
@@ -13,6 +13,7 @@ import (
 
 type Rollout = models.Rollout
 type Update = models.Update
+type UpdateSummary = models.UpdateSummary
 
 type UpdatesApi struct {
 	api *Api
@@ -31,6 +32,18 @@ func (u UpdatesApi) Get(tag, updateName string) ([]string, error) {
 	var rollouts []string
 	endpoint := "/v1/updates/" + tag + "/" + updateName + "/rollouts"
 	return rollouts, u.api.Get(endpoint, &rollouts)
+}
+
+func (u UpdatesApi) GetSummary(tag, updateName string) (UpdateSummary, error) {
+	var summary UpdateSummary
+	endpoint := "/v1/updates/" + tag + "/" + updateName + "/summary"
+	return summary, u.api.Get(endpoint, &summary)
+}
+
+func (u UpdatesApi) GetDevicesForStatus(tag, updateName, status string) ([]string, error) {
+	var devices []string
+	endpoint := "/v1/updates/" + tag + "/" + updateName + "/query?status=" + url.QueryEscape(status)
+	return devices, u.api.Get(endpoint, &devices)
 }
 
 // UpdateTuf holds the TUF metadata for an update keyed by role file name
@@ -53,6 +66,18 @@ func (u UpdatesApi) GetRollout(tag, updateName, rollout string) (Rollout, error)
 	var r Rollout
 	endpoint := "/v1/updates/" + tag + "/" + updateName + "/rollouts/" + rollout
 	return r, u.api.Get(endpoint, &r)
+}
+
+func (u UpdatesApi) GetRolloutSummary(tag, updateName, rollout string) (UpdateSummary, error) {
+	var report UpdateSummary
+	endpoint := "/v1/updates/" + tag + "/" + updateName + "/rollouts/" + rollout + "/summary"
+	return report, u.api.Get(endpoint, &report)
+}
+
+func (u UpdatesApi) GetDevicesForRolloutStatus(tag, updateName, rollout, status string) ([]string, error) {
+	var devices []string
+	endpoint := "/v1/updates/" + tag + "/" + updateName + "/rollouts/" + rollout + "/query?status=" + url.QueryEscape(status)
+	return devices, u.api.Get(endpoint, &devices)
 }
 
 func (u UpdatesApi) CreateRollout(tag, updateName, rollout string, data Rollout) error {

--- a/cli/subcommands/updates/show.go
+++ b/cli/subcommands/updates/show.go
@@ -13,6 +13,7 @@ import (
 )
 
 var showTufDetails bool
+var showDevices bool
 
 var showCmd = &cobra.Command{
 	Use:   "show <tag> <update-name>",
@@ -28,6 +29,7 @@ var showCmd = &cobra.Command{
 
 func init() {
 	showCmd.Flags().BoolVar(&showTufDetails, "tuf-details", false, "Print the raw TUF metadata")
+	showCmd.Flags().BoolVar(&showDevices, "show-devices", false, "Print the device UUIDs in the rollout summary")
 	UpdatesCmd.AddCommand(showCmd)
 }
 
@@ -38,6 +40,8 @@ func showUpdate(updates api.UpdatesApi, tag, updateName string) {
 	fmt.Println("# Details")
 	fmt.Printf("Update: %s\n", updateName)
 	fmt.Printf("Tag: %s\n\n", tag)
+
+	showRolloutSummary(updates, tag, updateName)
 	showRollouts(updates, tag, updateName)
 
 	fmt.Println("# TUF metadata")
@@ -68,6 +72,32 @@ func showUpdate(updates api.UpdatesApi, tag, updateName string) {
 
 	fmt.Println("  Apps:")
 	printApps(custom)
+}
+
+func showRolloutSummary(updates api.UpdatesApi, tag, updateName string) {
+	fmt.Println("# Rollout summary")
+	summary, err := updates.GetSummary(tag, updateName)
+	if err != nil {
+		fmt.Printf("Error fetching rollout summary: %v\n\n", err)
+		return
+	}
+
+	for status, count := range summary.Status {
+		fmt.Printf("  %s: %d\n", status, count)
+		if showDevices {
+			fmt.Printf("    looking up devices ...")
+			devices, err := updates.GetDevicesForStatus(tag, updateName, status)
+			if err != nil {
+				fmt.Printf("\rError fetching devices for status %s: %v\n", status, err)
+			} else {
+				fmt.Printf("\r")
+				for _, device := range devices {
+					fmt.Printf("    %s\n", device)
+				}
+			}
+		}
+	}
+	fmt.Println()
 }
 
 func showRollouts(updates api.UpdatesApi, tag, updateName string) {

--- a/cli/subcommands/updates/showrollout.go
+++ b/cli/subcommands/updates/showrollout.go
@@ -23,6 +23,7 @@ var showRolloutCmd = &cobra.Command{
 }
 
 func init() {
+	showRolloutCmd.Flags().BoolVar(&showDevices, "show-devices", false, "Print the device UUIDs in the rollout summary")
 	UpdatesCmd.AddCommand(showRolloutCmd)
 }
 
@@ -34,6 +35,29 @@ func showRollout(updates api.UpdatesApi, tag, updateName, rollout string) {
 	fmt.Printf("Update: %s\n", updateName)
 	fmt.Printf("Tag: %s\n", tag)
 	fmt.Printf("Committed: %v\n\n", rolloutData.Commit)
+
+	summary, err := updates.GetRolloutSummary(tag, updateName, rollout)
+	if err != nil {
+		fmt.Printf("Error fetching rollout report: %v\n", err)
+		return
+	}
+	fmt.Println("Summary:")
+	for status, count := range summary.Status {
+		fmt.Printf("  %s: %d\n", status, count)
+		if showDevices {
+			fmt.Printf("    looking up devices ...")
+			devices, err := updates.GetDevicesForRolloutStatus(tag, updateName, rollout, status)
+			if err != nil {
+				fmt.Printf("\rError fetching devices for status %s: %v\n", status, err)
+			} else {
+				fmt.Printf("\r")
+				for _, device := range devices {
+					fmt.Printf("    %s\n", device)
+				}
+			}
+		}
+	}
+	fmt.Println()
 
 	if len(rolloutData.Groups) > 0 {
 		fmt.Println("Groups:")

--- a/server/ui/api/handlers.go
+++ b/server/ui/api/handlers.go
@@ -71,10 +71,14 @@ func RegisterHandlers(e *echo.Echo, ca *DeviceCa, storage *storage.Storage, a au
 	upd.POST("/:tag/:update", h.updateCreate, requireScope(users.ScopeUpdatesRU),
 		gzipContentTypeAsContentEncoding, middleware.Decompress())
 	upd.DELETE("/:tag/:update", h.updateDelete, requireScope(users.ScopeUpdatesD))
+	upd.GET("/:tag/:update/summary", h.updateSummary, requireScope(users.ScopeUpdatesR))
+	upd.GET("/:tag/:update/query", h.updateQuery, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/tuf", h.updateGetTuf, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/rollouts", h.rolloutList, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/rollouts/:rollout", h.rolloutGet, requireScope(users.ScopeUpdatesR))
 	upd.PUT("/:tag/:update/rollouts/:rollout", h.rolloutPut, requireScope(users.ScopeUpdatesRU))
+	upd.GET("/:tag/:update/rollouts/:rollout/summary", h.updateRolloutSummary, requireScope(users.ScopeUpdatesR))
+	upd.GET("/:tag/:update/rollouts/:rollout/query", h.updateRolloutQuery, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/rollouts/:rollout/tail", h.rolloutTail, requireScope(users.ScopeUpdatesR))
 	upd.GET("/:tag/:update/tail", h.updateTail, requireScope(users.ScopeUpdatesR))
 

--- a/server/ui/api/handlers_rollouts.go
+++ b/server/ui/api/handlers_rollouts.go
@@ -24,6 +24,7 @@ import (
 
 type Rollout = storage.Rollout
 type Update = storage.Update
+type UpdateSummary = storage.UpdateSummary
 
 // @Summary List updates
 // @Description Requires scope: updates:read or updates:read-update
@@ -43,6 +44,84 @@ func (h *handlers) updateList(c echo.Context) error {
 		}
 		return c.JSON(http.StatusOK, updates)
 	}
+}
+
+// @Summary Get summary of update
+// @Description Requires scope: updates:read or updates:read-update
+// @Tags    Updates
+// @Produce json
+// @Success 200 {object} UpdateSummary
+// @Param   tag path string true "Update tag"
+// @Param   update path string true "Update name"
+// @Router  /updates/{tag}/{update}/summary [get]
+func (h *handlers) updateSummary(c echo.Context) error {
+	tag := c.Param("tag")
+	updateName := c.Param("update")
+	summary, err := h.storage.UpdateSummary(tag, updateName)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get update summary")
+	}
+	return c.JSON(http.StatusOK, summary)
+}
+
+// @Summary Query for devices in a given state for an update
+// @Description Requires scope: updates:read or updates:read-update
+// @Tags    Updates
+// @Produce json
+// @Success 200 {array} string
+// @Param   tag path string true "Update tag"
+// @Param   update path string true "Update name"
+// @Router  /updates/{tag}/{update}/query [get]
+func (h *handlers) updateQuery(c echo.Context) error {
+	tag := c.Param("tag")
+	updateName := c.Param("update")
+	status := c.QueryParam("status")
+	devices, err := h.storage.UpdateStateFor(tag, updateName, status)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get update query")
+	}
+	return c.JSON(http.StatusOK, devices)
+}
+
+// @Summary Get summary of update
+// @Description Requires scope: updates:read or updates:read-update
+// @Tags    Updates
+// @Produce json
+// @Success 200 {object} UpdateSummary
+// @Param   tag path string true "Update tag"
+// @Param   update path string true "Update name"
+// @Param   rollout path string true "Rollout name"
+// @Router  /updates/{tag}/{update}/rollouts/{rollout}/summary [get]
+func (h *handlers) updateRolloutSummary(c echo.Context) error {
+	tag := c.Param("tag")
+	updateName := c.Param("update")
+	rolloutName := c.Param("rollout")
+	summary, err := h.storage.RolloutSummary(tag, updateName, rolloutName)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get rollout report")
+	}
+	return c.JSON(http.StatusOK, summary)
+}
+
+// @Summary Query for devices in a given state for an update
+// @Description Requires scope: updates:read or updates:read-update
+// @Tags    Updates
+// @Produce json
+// @Success 200 {array} string
+// @Param   tag path string true "Update tag"
+// @Param   update path string true "Update name"
+// @Param   rollout path string true "Rollout name"
+// @Router  /updates/{tag}/{update}/rollouts/{rollout}/query [get]
+func (h *handlers) updateRolloutQuery(c echo.Context) error {
+	tag := c.Param("tag")
+	updateName := c.Param("update")
+	rolloutName := c.Param("rollout")
+	status := c.QueryParam("status")
+	devices, err := h.storage.RolloutStateFor(tag, updateName, rolloutName, status)
+	if err != nil {
+		return EchoError(c, err, http.StatusInternalServerError, "Failed to get rollout query")
+	}
+	return c.JSON(http.StatusOK, devices)
 }
 
 // @Summary Tail update logs

--- a/server/ui/web/handlers_updates.go
+++ b/server/ui/web/handlers_updates.go
@@ -168,6 +168,11 @@ func (h handlers) updatesGet(c echo.Context) error {
 		return h.handleUnexpected(c, err)
 	}
 
+	var summary api.UpdateSummary
+	if err := getJson(c.Request().Context(), fmt.Sprintf("/v1/updates/%s/%s/summary", c.Param("tag"), c.Param("name")), &summary); err != nil {
+		return h.handleUnexpected(c, err)
+	}
+
 	var groups []string
 	if err := getJson(c.Request().Context(), "/v1/known-labels/device-groups", &groups); err != nil {
 		return h.handleUnexpected(c, err)
@@ -188,6 +193,7 @@ func (h handlers) updatesGet(c echo.Context) error {
 		baseCtx
 		Tag          string
 		Name         string
+		Summary      api.UpdateSummary
 		Rollouts     []string
 		Groups       []string
 		Tuf          api.UpdateTufResp
@@ -200,6 +206,7 @@ func (h handlers) updatesGet(c echo.Context) error {
 		baseCtx:      h.baseCtx(c, "Update Details", "updates"),
 		Tag:          c.Param("tag"),
 		Name:         c.Param("name"),
+		Summary:      summary,
 		Rollouts:     rollouts,
 		Groups:       groups,
 		Tuf:          tuf,
@@ -220,18 +227,25 @@ func (h handlers) updatesRollout(c echo.Context) error {
 		return EchoError(c, err, 500, err.Error())
 	}
 
+	var summary api.UpdateSummary
+	if err := getJson(c.Request().Context(), url+"/summary", &summary); err != nil {
+		return h.handleUnexpected(c, err)
+	}
+
 	ctx := struct {
 		baseCtx
 		Tag     string
 		Name    string
 		Rollout string
 		Details api.Rollout
+		Summary api.UpdateSummary
 	}{
 		baseCtx: h.baseCtx(c, "Rollout Details", "updates"),
 		Tag:     c.Param("tag"),
 		Name:    c.Param("name"),
 		Rollout: c.Param("rollout"),
 		Details: details,
+		Summary: summary,
 	}
 	return h.templates.ExecuteTemplate(c.Response(), "update_rollout.html", ctx)
 }

--- a/server/ui/web/templates/templates.go
+++ b/server/ui/web/templates/templates.go
@@ -5,6 +5,7 @@ package templates
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"strings"
@@ -54,6 +55,10 @@ func init() {
 			return a - b
 		},
 		"contains": strings.Contains,
+		"json": func(v any) (template.JS, error) {
+			b, err := json.Marshal(v)
+			return template.JS(b), err
+		},
 	}
 
 	Templates = template.Must(template.New("").Funcs(funcMap).ParseFS(Assets, "*.html", "*.css"))

--- a/server/ui/web/templates/update.html
+++ b/server/ui/web/templates/update.html
@@ -2,15 +2,34 @@
     <section class="content-section">
       <h2>{{.Title}}</h2>
 
-      <fieldset>
-        <legend><strong>Tag</strong></legend>
-        <p>{{.Tag}}</p>
-      </fieldset>
+      <div class="grid">
+        <div>
+          <fieldset>
+            <legend><strong>Tag</strong></legend>
+            <p>{{.Tag}}</p>
+          </fieldset>
 
-      <fieldset>
-        <legend><strong>Name</strong></legend>
-        <p>{{.Name}}</p>
-      </fieldset>
+          <fieldset>
+            <legend><strong>Name</strong></legend>
+            <p>{{.Name}}</p>
+          </fieldset>
+        </div> 
+
+        <div>
+         <fieldset>
+            <legend><strong>Rollout summary</strong></legend>
+            <ul>
+            {{ if len .Summary.Status }}
+              {{ range $status, $count := .Summary.Status }}
+                <li><strong>{{ $status }}:</strong> <a href="#" onclick="showDevicesModal('{{ $status }}'); return false;">{{ $count }} devices</a></li>
+              {{ end }}
+            {{ else }}
+              <li>No rollout summary available.</li>
+            {{ end }}
+            </ul>
+          </fieldset> 
+        </div> 
+      </div>
 
       <button onclick='location.href="/updates/{{$.Tag}}/{{$.Name}}/tail";'>Follow progress</button>
       <button onclick="rolloutModal.show()">Create rollout</button>
@@ -50,8 +69,22 @@
           </footer>
         </article>
       </dialog>
-    </section>
 
+      <dialog id="devicesModal">
+        <article>
+          <header>
+            <button aria-label="Close" rel="prev" onclick="devicesModal.close()"></button>
+            <h3>Devices - <span id="devicesStatus"></span></h3>
+          </header>
+          <div id="devicesContent">
+            <ul id="devicesList"></ul>
+          </div>
+          <footer>
+            <button role="button" onclick="devicesModal.close()">Close</button>
+          </footer>
+        </article>
+      </dialog>
+    </section>
 
     <section class="content-section">
       <h2>TUF Metadata</h2>
@@ -161,6 +194,34 @@
     </section>
 
     <script>
+      function showDevicesModal(status) {
+        document.getElementById('devicesStatus').textContent = status;
+        const list = document.getElementById('devicesList');
+        list.innerHTML = '<li>Loading...</li>';
+        devicesModal.show();
+        fetch('/v1/updates/{{.Tag}}/{{.Name}}/query?status=' + encodeURIComponent(status))
+          .then(response => response.json())
+          .then(data => {
+            const devicesList = data || [];
+            list.innerHTML = '';
+            devicesList.forEach(uuid => {
+              const li = document.createElement('li');
+              const a = document.createElement('a');
+              a.href = '/devices/' + uuid;
+              a.textContent = uuid;
+              li.appendChild(a);
+              list.appendChild(li);
+            });
+          })
+          .catch(error => {
+            console.error('Error fetching devices:', error);
+            list.innerHTML = '';
+            const li = document.createElement('li');
+            li.textContent = 'Error loading devices';
+            list.appendChild(li);
+          });
+      }
+
       function createRollout() {
         // Get form values
         const uuids = document.getElementById('uuids').value;

--- a/server/ui/web/templates/update_rollout.html
+++ b/server/ui/web/templates/update_rollout.html
@@ -2,21 +2,39 @@
     <section class="content-section">
       <h2>{{.Title}}</h2>
 
-      <fieldset>
-        <legend><strong>Tag</strong></legend>
-        <p>{{.Tag}}</p>
-      </fieldset>
+      <div class="grid">
+        <div>
+          <fieldset>
+            <legend><strong>Tag</strong></legend>
+            <p>{{.Tag}}</p>
+          </fieldset>
 
-      <fieldset>
-        <legend><strong>Name</strong></legend>
-        <p>{{.Name}}</p>
-      </fieldset>
-      
-      <fieldset>
-        <legend><strong>Rollout</strong></legend>
-        <p>{{.Rollout}}</p>
-      </fieldset>
+          <fieldset>
+            <legend><strong>Name</strong></legend>
+            <p>{{.Name}}</p>
+          </fieldset>
+          
+          <fieldset>
+            <legend><strong>Rollout</strong></legend>
+            <p>{{.Rollout}}</p>
+          </fieldset>
+        </div>
 
+        <div>
+         <fieldset>
+            <legend><strong>Rollout summary</strong></legend>
+            <ul>
+            {{ if len .Summary.Status }}
+              {{ range $status, $count := .Summary.Status }}
+                <li><strong>{{ $status }}:</strong> <a href="#" onclick="showDevicesModal('{{ $status }}'); return false;">{{ $count }} devices</a></li>
+              {{ end }}
+            {{ else }}
+              <li>No rollout summary available.</li>
+            {{ end }}
+            </ul>
+          </fieldset> 
+        </div>
+      </div>
       <button onclick='location.href="/updates/{{$.Tag}}/{{$.Name}}/rollouts/{{.Rollout}}/tail";'>Follow progress</button>
     </section>
 
@@ -64,5 +82,50 @@
       </table>
       {{ end }}
     </section>
+
+    <dialog id="devicesModal">
+      <article>
+        <header>
+          <button aria-label="Close" rel="prev" onclick="devicesModal.close()"></button>
+          <h3>Devices - <span id="devicesStatus"></span></h3>
+        </header>
+        <div id="devicesContent">
+          <ul id="devicesList"></ul>
+        </div>
+        <footer>
+          <button role="button" onclick="devicesModal.close()">Close</button>
+        </footer>
+      </article>
+    </dialog>
+
+    <script>
+      function showDevicesModal(status) {
+        document.getElementById('devicesStatus').textContent = status;
+        const list = document.getElementById('devicesList');
+        list.innerHTML = '<li>Loading...</li>';
+        devicesModal.show();
+        fetch('/v1/updates/{{.Tag}}/{{.Name}}/rollouts/{{.Rollout}}/query?status=' + encodeURIComponent(status))
+          .then(response => response.json())
+          .then(data => {
+            const devicesList = data || [];
+            list.innerHTML = '';
+            devicesList.forEach(uuid => {
+              const li = document.createElement('li');
+              const a = document.createElement('a');
+              a.href = '/devices/' + uuid;
+              a.textContent = uuid;
+              li.appendChild(a);
+              list.appendChild(li);
+            });
+          })
+          .catch(error => {
+            console.error('Error fetching devices:', error);
+            list.innerHTML = '';
+            const li = document.createElement('li');
+            li.textContent = 'Error loading devices';
+            list.appendChild(li);
+          });
+      }
+    </script>
 
 {{ template "footer"}}

--- a/storage/api/api_storage_update.go
+++ b/storage/api/api_storage_update.go
@@ -5,6 +5,8 @@ package api
 
 import (
 	"crypto/sha256"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,6 +17,126 @@ import (
 	"github.com/foundriesio/update-server/storage"
 	"github.com/foundriesio/update-server/storage/ostree"
 )
+
+// A special status used to indicate that a device was expected to be part of the rollout
+// but is not present in the rollout log.
+const MissingState = "Missing"
+
+type UpdateSummary struct {
+	// A map of device status to the number of devices in that status for the update.
+	Status map[string]int `json:"summaries"`
+}
+
+func (s Storage) lastKnownStates(tag, name string, filterUuids map[string]any) (map[string]string, error) {
+	lastStates := make(map[string]string)
+
+	// Collect the last known state for each device in the rollout.
+	for line, err := range s.TailRolloutsLog(tag, name, nil) {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// No rollout log yet, return an empty report.
+				return nil, nil
+			}
+			return nil, err
+		}
+		var status DeviceStatus
+		if err = json.Unmarshal([]byte(line), &status); err == nil {
+			if filterUuids != nil {
+				if _, ok := filterUuids[status.Uuid]; !ok {
+					continue
+				}
+			}
+			lastStates[status.Uuid] = status.Status
+		}
+	}
+
+	return lastStates, nil
+}
+
+func (s Storage) updateSummary(tag, name string, filterUuids map[string]any) (*UpdateSummary, error) {
+	lastStates, err := s.lastKnownStates(tag, name, filterUuids)
+	if err != nil {
+		return nil, err
+	} else if lastStates == nil {
+		return &UpdateSummary{
+			Status: make(map[string]int),
+		}, nil
+	}
+
+	report := &UpdateSummary{Status: make(map[string]int)}
+	for uuid, status := range lastStates {
+		count, ok := report.Status[status]
+		if !ok {
+			count = 0
+		}
+		report.Status[status] = count + 1
+		if filterUuids != nil {
+			delete(filterUuids, uuid)
+		}
+	}
+	if len(filterUuids) > 0 {
+		report.Status[MissingState] = len(filterUuids)
+	}
+	return report, nil
+}
+
+func (s Storage) updateStateFor(tag, name, filterState string, filterUuids map[string]any) ([]string, error) {
+	lastStates, err := s.lastKnownStates(tag, name, filterUuids)
+	if err != nil {
+		return nil, err
+	} else if lastStates == nil {
+		return []string{}, nil
+	}
+
+	result := make([]string, 0, len(lastStates))
+	for uuid, state := range lastStates {
+		if state == filterState {
+			result = append(result, uuid)
+		}
+		if filterUuids != nil {
+			delete(filterUuids, uuid)
+		}
+	}
+	if filterState == MissingState {
+		result = make([]string, 0, len(filterUuids))
+		for uuid := range filterUuids {
+			result = append(result, uuid)
+		}
+	}
+	return result, nil
+}
+
+func (s Storage) UpdateSummary(tag, name string) (*UpdateSummary, error) {
+	return s.updateSummary(tag, name, nil)
+}
+
+func (s Storage) UpdateStateFor(tag, updateName, status string) ([]string, error) {
+	return s.updateStateFor(tag, updateName, status, nil)
+}
+
+func (s Storage) RolloutSummary(tag, updateName, rolloutName string) (*UpdateSummary, error) {
+	rollout, err := s.GetRollout(tag, updateName, rolloutName)
+	if err != nil {
+		return nil, err
+	}
+	filter := make(map[string]any, len(rollout.Effect))
+	for _, uuid := range rollout.Effect {
+		filter[uuid] = nil
+	}
+	return s.updateSummary(tag, updateName, filter)
+}
+
+func (s Storage) RolloutStateFor(tag, updateName, rolloutName, status string) ([]string, error) {
+	rollout, err := s.GetRollout(tag, updateName, rolloutName)
+	if err != nil {
+		return nil, err
+	}
+	filter := make(map[string]any, len(rollout.Effect))
+	for _, uuid := range rollout.Effect {
+		filter[uuid] = nil
+	}
+	return s.updateStateFor(tag, updateName, status, filter)
+}
 
 // generateUpdateTuf probes the uploaded ostree/apps content for an update and
 // generates its TUF metadata via AddTarget. Values discovered from the upload


### PR DESCRIPTION
This helps address issue #71 in a different way that's more useful for someone operating a larger fleet.

Web UI change looks like:
<img width="1507" height="337" alt="image" src="https://github.com/user-attachments/assets/56d7faa7-d517-4e58-87f5-f149aba570bd" />
when clicking on a sampling you see:
<img width="1031" height="807" alt="image" src="https://github.com/user-attachments/assets/47360f3b-8288-4f1e-b387-3a17905cb053" />

The CLI looks like:
```
$ fiocli updates show a a 
# Details
Update: a
Tag: a

# Rollout summary
  Installation completed; failed: 6
  Installation completed; succeeded: 19
  Metadata update completed; failed: 10

# Rollouts: None

# TUF metadata
  Latest target name: aaa-1
...
```
