### PR TITLE
Add Terraform logic for deploying to AWS

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -1,0 +1,74 @@
+name: Terraform Lint
+on:
+  pull_request:
+    paths:
+      - 'contrib/terraform/**'
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.12.2"
+          terraform_wrapper: false
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive contrib/terraform
+
+      - name: terraform init & validate
+        run: |
+          set -e
+          for dir in $(find contrib/terraform -name '*.tf' -exec dirname {} \; | sort -u); do
+            echo "::group::terraform validate $dir"
+            (cd "$dir" && terraform init -backend=false -input=false && terraform validate)
+            echo "::endgroup::"
+          done
+
+      - name: Setup tflint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.55.1
+
+      - name: tflint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          tflint --init --config "$GITHUB_WORKSPACE/contrib/terraform/.tflint.hcl"
+          for dir in $(find contrib/terraform -name '*.tf' -exec dirname {} \; | sort -u); do
+            echo "::group::tflint $dir"
+            tflint --config "$GITHUB_WORKSPACE/contrib/terraform/.tflint.hcl" --chdir "$dir"
+            echo "::endgroup::"
+          done
+
+  packer:
+    name: packer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@v3
+        with:
+          version: "1.13.1"
+
+      - name: packer fmt & validate
+        run: |
+          set -e
+          for f in $(find contrib/terraform -name '*.pkr.hcl'); do
+            echo "::group::packer $f"
+            packer fmt -check "$f"
+            packer init "$f"
+            packer validate -var fioserver_version=ci-lint "$f"
+            echo "::endgroup::"
+          done

--- a/contrib/terraform/.tflint.hcl
+++ b/contrib/terraform/.tflint.hcl
@@ -1,0 +1,11 @@
+plugin "aws" {
+  enabled = true
+  version = "0.48.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.39.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}

--- a/contrib/terraform/aws/.gitignore
+++ b/contrib/terraform/aws/.gitignore
@@ -1,0 +1,16 @@
+packer_build/
+*.pkr.hcl.json
+
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+
+# Never commit real variable values: they can carry OAuth client secrets via
+# auth_config_json. The .example files are the tracked templates.
+*.tfvars
+*.tfvars.json
+!*.tfvars.example

--- a/contrib/terraform/aws/.gitignore
+++ b/contrib/terraform/aws/.gitignore
@@ -9,8 +9,8 @@ packer_build/
 crash.log
 crash.*.log
 
-# Never commit real variable values: they can carry OAuth client secrets via
-# auth_config_json. The .example files are the tracked templates.
+# Never commit real variable values. The .example files are the tracked
+# templates.
 *.tfvars
 *.tfvars.json
 !*.tfvars.example

--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -30,11 +30,12 @@ VerifyClientCertIfGiven`, with the device CA in `certs/cas.pem`). Terminating
 that at an L7 proxy would discard the certificate the server needs, so the NLB
 forwards TCP untouched.
 
-**Terraform cannot create the TUF keys.** They are encrypted at rest with a key
-derived from `auth/hmac.secret`, so they must be generated on the instance. That
-turns out to be a benefit: no key material ever enters Terraform state. The
-instance generates its own secrets on first boot and pushes them to Secrets
-Manager using its instance profile.
+**Terraform never touches the TUF keys.** They are encrypted at rest with a key
+derived from `auth/hmac.secret`, so both must be generated together, before the
+instance boots. `scripts/init-secrets.sh` generates the hmac secret, PKI, and TUF
+keys locally with the `fioserver` binary and escrows them in Secrets Manager; the
+instance's IAM role only ever reads that escrow back, and no key material ever
+enters Terraform state.
 
 **The gateway hostname is effectively immutable.** `pki-init --dnsname` becomes
 the first DNS SAN of the gateway certificate, and the server derives every
@@ -46,9 +47,9 @@ device-facing URL from it — each enrolled device stores those URLs in its
 - Terraform >= 1.5, Packer >= 1.9, AWS CLI v2, credentials with permission to
   create VPC, EC2, ELB, IAM, Secrets Manager, DLM and (optionally) Route53
   resources.
-- A Route53 hosted zone. Optional but strongly recommended: without it, `apply`
-  blocks on ACM validation, and Caddy cannot obtain a certificate until DNS
-  resolves.
+- A local `fioserver` binary matching the version in the AMI, for
+  `scripts/init-secrets.sh` (release binaries are linux-amd64/linux-arm64 only;
+  build from source for other platforms).
 
 ## 1. Build the AMI
 
@@ -68,55 +69,54 @@ The resulting AMI ID is printed at the end and written to `packer/manifest.json`
 
 ## 2. Deploy
 
+Generate and escrow the hmac secret, PKI, and TUF keys with
+`scripts/init-secrets.sh` **before** running `terraform apply` — it creates
+the Secrets Manager containers itself, and Terraform only ever reads them
+back via a data source. Running `apply` first fails immediately at that
+lookup, rather than succeeding and letting the instance fail loudly at boot.
+
 ```bash
-cd examples/with-load-balancer
+cd scripts
+./init-secrets.sh --hostname dg.example.com --gateway-hostname devices.example.com \
+    --factory my-factory --auth-config-json /path/to/auth-config.json
+```
+
+The values passed here must match the corresponding Terraform variables
+exactly — they compute the same Secrets Manager names and PKI/TUF identity
+Terraform expects the instance to restore. In the load-balancer topology the
+UI and the gateway need **separate hostnames**, because one DNS record
+cannot alias to two different load balancers.
+
+```bash
+cd ../examples/with-load-balancer
 cp terraform.tfvars.example terraform.tfvars
 $EDITOR terraform.tfvars      # set ami_id, hostname, gateway_hostname, hosted_zone_id
 terraform init
 terraform apply
 ```
 
-In the load-balancer topology the UI and the gateway need **separate hostnames**,
-because one DNS record cannot alias to two different load balancers.
-
-First boot then runs, in order: `auth-init`, writes `auth-config.json`,
-`pki-init`, `tuf-init`, and finally escrows the results. Watch it with:
+First boot then restores `auth-config.json`, `hmac.secret`, `certs/` and `tuf/`
+from that escrow — it never generates key material itself. Watch it with:
 
 ```bash
 aws ssm start-session --target "$(terraform output -raw instance_id)"
 sudo journalctl -u fioserver-bootstrap -f
 ```
 
-### Authentication
+```bash
+aws ssm start-session --target "$(terraform output -raw instance_id)"
+sudo fioserver --datadir /data user-add --username admin --password <password>
+```
 
-Leave `auth_config_json` unset and the instance configures local auth, creating
-an `admin` user whose generated password is escrowed:
+To change the auth config on an already-deployed stack, populate the secret out
+of band instead of re-running `init-secrets.sh` (which would mint a new hmac
+secret and PKI/TUF identity):
 
 ```bash
-eval "$(terraform output -raw admin_password_command)"
+aws secretsmanager put-secret-value \
+  --secret-id "$(terraform output -raw secret_prefix)/auth-config" \
+  --secret-string file://auth-config.json
 ```
-
-Otherwise supply a config — see [docs/auth.md](../../../docs/auth.md) and the
-`contrib/auth-config-{local,github,google}.json` templates:
-
-```hcl
-auth_config_json = <<-EOT
-...
-EOF
-```
-
-For OAuth providers, `Config.BaseUrl` must be `https://<hostname>` and the
-provider's authorized redirect URI must be `https://<hostname>/auth/callback`.
-
-> [!NOTE]
-> A value passed through `auth_config_json` is stored in Terraform state. To keep
-> an OAuth client secret out of state, leave the variable empty and populate the
-> secret out of band instead:
-> ```bash
-> aws secretsmanager put-secret-value \
->   --secret-id "$(terraform output -raw secret_prefix)/auth-config" \
->   --secret-string file://auth-config.json
-> ```
 
 ## 3. Verify
 
@@ -151,11 +151,10 @@ Secrets Manager holds, under `<name_prefix>/<hostname>/`:
 
 | Secret | Written by | Contents |
 | --- | --- | --- |
-| `auth-config` | Terraform, or the instance | `auth-config.json` |
-| `hmac-secret` | instance | `auth/hmac.secret`, base64 |
-| `certs-archive` | instance | gzipped tar of `certs/` |
-| `tuf-archive` | instance | gzipped tar of `tuf/` |
-| `admin-password` | instance | generated admin password, if applicable |
+| `auth-config` | `scripts/init-secrets.sh` | `auth-config.json` |
+| `hmac-secret` | `scripts/init-secrets.sh` | `auth/hmac.secret`, base64 |
+| `certs-archive` | `scripts/init-secrets.sh` | gzipped tar of `certs/` |
+| `tuf-archive` | `scripts/init-secrets.sh` | gzipped tar of `tuf/` |
 
 Whole directories are archived rather than individual keys because a restore
 needs more than the roots of trust: devices authenticate against `cas.pem` and
@@ -172,7 +171,8 @@ cannot rebuild a partial `certs/` — it refuses to run if any file there exists
 ### Restoring onto a fresh volume
 
 This is automatic. Boot a new instance with an empty data volume and the same
-`FIOSERVER_SECRET_PREFIX`; the bootstrap detects the escrow and restores
+`FIOSERVER_SECRET_PREFIX` (i.e. the escrow already populated by
+`scripts/init-secrets.sh`); the bootstrap detects it and restores
 `hmac.secret`, `auth-config.json`, `certs/` and `tuf/` byte-for-byte, so
 already-enrolled devices keep working without re-enrolment.
 
@@ -183,7 +183,7 @@ while `fioserver` is stopped.
 Check which path a boot took:
 
 ```bash
-cat /data/.bootstrap-state   # "A" reboot, "B" restored, "C" initialized
+cat /data/.bootstrap-state   # "A" reboot, "B" restored from escrow
 ```
 
 ## Backups
@@ -208,7 +208,6 @@ makes `apply` fail on a fresh account.
   available.
 - **`terraform destroy` deletes the data volume.** Snapshots and the secret
   escrow are the recovery path. There is deliberately no `prevent_destroy`, since
-  that would make `destroy` fail and leave the volume stranded.
-- **Secrets have a recovery window.** After a destroy they sit pending deletion,
-  and re-applying with the same hostname fails until they are purged or restored.
-  Set `secret_recovery_window_days = 0` in throwaway environments.
+  that would make `destroy` fail and leave the volume stranded. The secret
+  escrow itself is untouched by `destroy` — Terraform only ever reads it — so
+  re-applying against the same hostname finds it intact.

--- a/contrib/terraform/aws/README.md
+++ b/contrib/terraform/aws/README.md
@@ -1,0 +1,214 @@
+<!--
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+-->
+
+# Deploying the update server on AWS
+
+Packer builds an AMI holding the `fioserver` release binary; Terraform deploys it
+onto a single EC2 instance with a persistent EBS volume, daily snapshots, and the
+server's irreplaceable secrets escrowed in AWS Secrets Manager.
+
+Two topologies are provided:
+
+| | `examples/with-load-balancer` | `examples/without-load-balancer` |
+| --- | --- | --- |
+| UI TLS | Application Load Balancer(ALB) with an ACM certificate | Caddy on the instance, Let's Encrypt |
+| Device gateway | Network Load Balancer(NLB), TCP passthrough | Exposed directly on the instance |
+| DNS Names | two (UI and gateway for the 2 LBs) | one |
+| Extra cost | yes | no |
+
+Both share the same modules and the same AMI.
+
+## Why it is shaped this way
+
+Three properties of the server drive you will deploy.
+
+**Port 8443 must be L4 passthrough.** The device gateway terminates TLS itself
+and authenticates devices by client certificate (`ClientAuth:
+VerifyClientCertIfGiven`, with the device CA in `certs/cas.pem`). Terminating
+that at an L7 proxy would discard the certificate the server needs, so the NLB
+forwards TCP untouched.
+
+**Terraform cannot create the TUF keys.** They are encrypted at rest with a key
+derived from `auth/hmac.secret`, so they must be generated on the instance. That
+turns out to be a benefit: no key material ever enters Terraform state. The
+instance generates its own secrets on first boot and pushes them to Secrets
+Manager using its instance profile.
+
+**The gateway hostname is effectively immutable.** `pki-init --dnsname` becomes
+the first DNS SAN of the gateway certificate, and the server derives every
+device-facing URL from it — each enrolled device stores those URLs in its
+`sota.toml`. Changing the name later orphans existing devices.
+
+## Prerequisites
+
+- Terraform >= 1.5, Packer >= 1.9, AWS CLI v2, credentials with permission to
+  create VPC, EC2, ELB, IAM, Secrets Manager, DLM and (optionally) Route53
+  resources.
+- A Route53 hosted zone. Optional but strongly recommended: without it, `apply`
+  blocks on ACM validation, and Caddy cannot obtain a certificate until DNS
+  resolves.
+
+## 1. Build the AMI
+
+```bash
+cd packer
+packer init .
+packer build -var fioserver_version=v0.9.2 .
+```
+
+The version is required and deliberately has no default, so an AMI is always
+reproducible. Releases publish bare, uncompressed binaries
+(`fioserver-linux-amd64`, `fioserver-linux-arm64`), and the build records the
+version and SHA256 in `/etc/fioserver/build-info`. For Graviton, add
+`-var architecture=arm64` and choose a `t4g`-class `instance_type` when deploying.
+
+The resulting AMI ID is printed at the end and written to `packer/manifest.json`.
+
+## 2. Deploy
+
+```bash
+cd examples/with-load-balancer
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars      # set ami_id, hostname, gateway_hostname, hosted_zone_id
+terraform init
+terraform apply
+```
+
+In the load-balancer topology the UI and the gateway need **separate hostnames**,
+because one DNS record cannot alias to two different load balancers.
+
+First boot then runs, in order: `auth-init`, writes `auth-config.json`,
+`pki-init`, `tuf-init`, and finally escrows the results. Watch it with:
+
+```bash
+aws ssm start-session --target "$(terraform output -raw instance_id)"
+sudo journalctl -u fioserver-bootstrap -f
+```
+
+### Authentication
+
+Leave `auth_config_json` unset and the instance configures local auth, creating
+an `admin` user whose generated password is escrowed:
+
+```bash
+eval "$(terraform output -raw admin_password_command)"
+```
+
+Otherwise supply a config — see [docs/auth.md](../../../docs/auth.md) and the
+`contrib/auth-config-{local,github,google}.json` templates:
+
+```hcl
+auth_config_json = <<-EOT
+...
+EOF
+```
+
+For OAuth providers, `Config.BaseUrl` must be `https://<hostname>` and the
+provider's authorized redirect URI must be `https://<hostname>/auth/callback`.
+
+> [!NOTE]
+> A value passed through `auth_config_json` is stored in Terraform state. To keep
+> an OAuth client secret out of state, leave the variable empty and populate the
+> secret out of band instead:
+> ```bash
+> aws secretsmanager put-secret-value \
+>   --secret-id "$(terraform output -raw secret_prefix)/auth-config" \
+>   --secret-string file://auth-config.json
+> ```
+
+## 3. Verify
+
+```bash
+HOST=$(terraform output -raw ui_url)
+curl -sI "$HOST/favicon"            # 200
+curl -sI "http://${HOST#https://}"  # 301 to HTTPS
+```
+
+Then log in through a browser and open a device or update page. That exercises
+the UI's own REST calls, which is the real test that `X-Forwarded-Proto` and the
+self-call are both working. If those pages error, check `journalctl -u fioserver`
+for attempts to reach `http://`.
+
+To verify device mTLS, generate a device certificate against the deployed PKI and
+use it (on the instance, where `/data` is the datadir).
+
+## What is stored where
+
+`/data` is the server's `--datadir` and the only writable location on the
+instance:
+
+```
+/data/db.sqlite          devices, users, updates, sessions
+/data/auth/              hmac.secret, auth-config.json
+/data/certs/             tls.{key,pem}, cas.pem, root.{key,crt}, device-ca.{key,crt}
+/data/tuf/               role keys and root metadata
+/data/caddy/             Let's Encrypt certificates (no-load-balancer topology)
+```
+
+Secrets Manager holds, under `<name_prefix>/<hostname>/`:
+
+| Secret | Written by | Contents |
+| --- | --- | --- |
+| `auth-config` | Terraform, or the instance | `auth-config.json` |
+| `hmac-secret` | instance | `auth/hmac.secret`, base64 |
+| `certs-archive` | instance | gzipped tar of `certs/` |
+| `tuf-archive` | instance | gzipped tar of `tuf/` |
+| `admin-password` | instance | generated admin password, if applicable |
+
+Whole directories are archived rather than individual keys because a restore
+needs more than the roots of trust: devices authenticate against `cas.pem` and
+`device-ca.crt`, and the TUF metadata chain must match the keys. `pki-init`
+cannot rebuild a partial `certs/` — it refuses to run if any file there exists.
+
+> [!IMPORTANT]
+> The escrow preserves the server's **identity**, not its **data**. `db.sqlite`
+> is not in it. If the volume is lost, the PKI comes back from Secrets Manager
+> but device and update records come back only from a snapshot.
+
+## Runbooks
+
+### Restoring onto a fresh volume
+
+This is automatic. Boot a new instance with an empty data volume and the same
+`FIOSERVER_SECRET_PREFIX`; the bootstrap detects the escrow and restores
+`hmac.secret`, `auth-config.json`, `certs/` and `tuf/` byte-for-byte, so
+already-enrolled devices keep working without re-enrolment.
+
+To also recover the database, restore the most recent snapshot into a volume,
+attach it, and copy `db.sqlite`, `db.sqlite-wal` and `db.sqlite-shm` into `/data`
+while `fioserver` is stopped.
+
+Check which path a boot took:
+
+```bash
+cat /data/.bootstrap-state   # "A" reboot, "B" restored, "C" initialized
+```
+
+## Backups
+
+A Data Lifecycle Manager policy snapshots the data volume every 24 hours and
+deletes snapshots older than `snapshot_retention_days` (60 by default). The
+module creates its own DLM IAM role: `AWSDataLifecycleManagerDefaultRole` is
+created implicitly by the AWS console but never by the API, so relying on it
+makes `apply` fail on a fresh account.
+
+> [!NOTE]
+> These snapshots are crash-consistent, not application-consistent. SQLite in WAL
+> mode recovers from them in practice, but a pre-snapshot `sqlite3 .backup` or
+> [Litestream](https://litestream.io/) replication would be strictly better. See
+> [docs/production.md](../../../docs/production.md).
+
+## Limitations
+
+- **One instance, one AZ.** The load balancers span two subnets because an ALB
+  requires it, but there is a single instance and a single volume. The server
+  keeps one SQLite database with `MaxOpenConns(1)`, so horizontal scaling is not
+  available.
+- **`terraform destroy` deletes the data volume.** Snapshots and the secret
+  escrow are the recovery path. There is deliberately no `prevent_destroy`, since
+  that would make `destroy` fail and leave the volume stranded.
+- **Secrets have a recovery window.** After a destroy they sit pending deletion,
+  and re-applying with the same hostname fails until they are purged or restored.
+  Set `secret_recovery_window_days = 0` in throwaway environments.

--- a/contrib/terraform/aws/examples/with-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/main.tf
@@ -85,6 +85,7 @@ module "frontend" {
   alb_security_group_id = module.network.alb_security_group_id
   certificate_arn       = module.dns.certificate_arn
   gateway_port          = var.gateway_port
+  access_logs           = var.access_logs
 
   tags = var.tags
 }

--- a/contrib/terraform/aws/examples/with-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/main.tf
@@ -46,9 +46,7 @@ module "server" {
 
   name_prefix       = var.name_prefix
   hostname          = var.hostname
-  gateway_hostname  = var.gateway_hostname
   gateway_port      = var.gateway_port
-  factory           = var.factory
   ami_id            = var.ami_id
   subnet_id         = module.network.public_subnet_ids[0]
   availability_zone = local.azs[0]
@@ -57,8 +55,6 @@ module "server" {
   instance_type    = var.instance_type
   data_volume_size = var.data_volume_size
   ssh_key_name     = var.ssh_key_name
-  auth_config_json = var.auth_config_json
-  tls_expiry_days  = var.tls_expiry_days
 
   snapshot_retention_days = var.snapshot_retention_days
   tags                    = var.tags

--- a/contrib/terraform/aws/examples/with-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/main.tf
@@ -37,6 +37,7 @@ module "network" {
   availability_zones = local.azs
   allowed_ssh_cidr   = var.allowed_ssh_cidr
   enable_alb_ingress = true
+  gateway_port       = var.gateway_port
   tags               = var.tags
 }
 
@@ -46,6 +47,7 @@ module "server" {
   name_prefix       = var.name_prefix
   hostname          = var.hostname
   gateway_hostname  = var.gateway_hostname
+  gateway_port      = var.gateway_port
   factory           = var.factory
   ami_id            = var.ami_id
   subnet_id         = module.network.public_subnet_ids[0]
@@ -86,6 +88,7 @@ module "frontend" {
   target_ip             = module.server.private_ip
   alb_security_group_id = module.network.alb_security_group_id
   certificate_arn       = module.dns.certificate_arn
+  gateway_port          = var.gateway_port
 
   tags = var.tags
 }

--- a/contrib/terraform/aws/examples/with-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/main.tf
@@ -1,0 +1,91 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Update server behind load balancers: an ALB terminates TLS for the UI with an
+# ACM certificate, and an NLB passes the device gateway through untouched.
+#
+# The UI and the gateway need SEPARATE hostnames here, because one DNS record
+# cannot alias to two different load balancers. Devices use the gateway name.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  # An ALB needs two AZs; the instance and its volume live in the first.
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name_prefix        = var.name_prefix
+  availability_zones = local.azs
+  allowed_ssh_cidr   = var.allowed_ssh_cidr
+  enable_alb_ingress = true
+  tags               = var.tags
+}
+
+module "server" {
+  source = "../../modules/server"
+
+  name_prefix       = var.name_prefix
+  hostname          = var.hostname
+  gateway_hostname  = var.gateway_hostname
+  factory           = var.factory
+  ami_id            = var.ami_id
+  subnet_id         = module.network.public_subnet_ids[0]
+  availability_zone = local.azs[0]
+  security_group_id = module.network.server_security_group_id
+
+  instance_type    = var.instance_type
+  data_volume_size = var.data_volume_size
+  ssh_key_name     = var.ssh_key_name
+  auth_config_json = var.auth_config_json
+  tls_expiry_days  = var.tls_expiry_days
+
+  snapshot_retention_days = var.snapshot_retention_days
+  tags                    = var.tags
+}
+
+module "dns" {
+  source = "../../modules/dns"
+
+  hostname         = var.hostname
+  gateway_hostname = var.gateway_hostname
+  hosted_zone_id   = var.hosted_zone_id
+
+  alb_dns_name = module.frontend.alb_dns_name
+  alb_zone_id  = module.frontend.alb_zone_id
+  nlb_dns_name = module.frontend.nlb_dns_name
+  nlb_zone_id  = module.frontend.nlb_zone_id
+
+  tags = var.tags
+}
+
+module "frontend" {
+  source = "../../modules/frontend"
+
+  name_prefix           = var.name_prefix
+  vpc_id                = module.network.vpc_id
+  subnet_ids            = module.network.public_subnet_ids
+  target_ip             = module.server.private_ip
+  alb_security_group_id = module.network.alb_security_group_id
+  certificate_arn       = module.dns.certificate_arn
+
+  tags = var.tags
+}

--- a/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
@@ -40,8 +40,3 @@ output "secret_prefix" {
   description = "Secrets Manager prefix holding the escrowed keys."
   value       = module.server.secret_prefix
 }
-
-output "admin_password_command" {
-  description = "Retrieve the generated admin password (only when auth_config_json was empty)."
-  value       = "aws secretsmanager get-secret-value --secret-id ${module.server.secret_prefix}/admin-password --query SecretString --output text"
-}

--- a/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
@@ -8,7 +8,7 @@ output "ui_url" {
 
 output "device_gateway_url" {
   description = "Gateway address devices connect to."
-  value       = "https://${var.gateway_hostname}:8443"
+  value       = "https://${var.gateway_hostname}:${var.gateway_port}"
 }
 
 output "alb_dns_name" {

--- a/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/outputs.tf
@@ -1,0 +1,47 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "ui_url" {
+  description = "Web UI address."
+  value       = "https://${var.hostname}"
+}
+
+output "device_gateway_url" {
+  description = "Gateway address devices connect to."
+  value       = "https://${var.gateway_hostname}:8443"
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name. Point var.hostname here if managing DNS yourself."
+  value       = module.frontend.alb_dns_name
+}
+
+output "nlb_dns_name" {
+  description = "NLB DNS name. Point var.gateway_hostname here if managing DNS yourself."
+  value       = module.frontend.nlb_dns_name
+}
+
+output "acm_validation_records" {
+  description = "Create these if hosted_zone_id is empty; apply blocks until they resolve."
+  value       = module.dns.validation_records
+}
+
+output "instance_id" {
+  description = "Instance ID, for `aws ssm start-session --target <id>`."
+  value       = module.server.instance_id
+}
+
+output "data_volume_id" {
+  description = "Persistent data volume ID."
+  value       = module.server.data_volume_id
+}
+
+output "secret_prefix" {
+  description = "Secrets Manager prefix holding the escrowed keys."
+  value       = module.server.secret_prefix
+}
+
+output "admin_password_command" {
+  description = "Retrieve the generated admin password (only when auth_config_json was empty)."
+  value       = "aws secretsmanager get-secret-value --secret-id ${module.server.secret_prefix}/admin-password --query SecretString --output text"
+}

--- a/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
@@ -1,0 +1,51 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Copy to terraform.tfvars and edit. Real .tfvars files are gitignored, because
+# auth_config_json can carry an OAuth client secret.
+
+aws_region = "us-east-1"
+ami_id     = "ami-0123456789abcdef0" # from `packer build`
+
+# The UI and the gateway need different names: the ALB and the NLB cannot share
+# one DNS record. Both must be in the hosted zone below.
+hostname         = "dg.example.com"
+gateway_hostname = "devices.example.com"
+
+factory = "my-factory"
+
+# Set this to your Route53 zone IFF you use it for DNS. Otherwise leave this blank.
+# If this is left blank, you will have to look for the ACM certificate validation
+# code and create a CNAME record with your DNS provider. The CNAME will be in the
+# form: _randomValue.dg.example.com -> CNAME(dg.example.com).
+# If you aren't using Route53, you'll also need to create CNAME records for your
+# hostname and gateway_hostname above that point to the load balancer DNS names
+# that get created by this recipe.
+hosted_zone_id = ""
+
+instance_type    = "t3.small"
+data_volume_size = 100
+
+# Access. Prefer SSM (`aws ssm start-session --target <instance-id>`) over
+# opening port 22; leaving both empty is fine and is the default.
+# ssh_key_name     = "my-key"
+# allowed_ssh_cidr = "203.0.113.0/24"
+
+# Authentication. Leave unset for local auth with a generated admin password
+# escrowed in Secrets Manager, or provide a config as a raw JSON literal:
+#
+#   auth_config_json = <<-EOT
+#   {
+#     "Type": "github",
+#     "BaseUrl": "https://dg.example.com",
+#     "ClientId": "your-client-id",
+#     "ClientSecret": "your-client-secret"
+#   }
+#   EOT
+#
+# See docs/auth.md and contrib/auth-config-{local,github,google}.json. For OAuth
+# providers, Config.BaseUrl must be "https://dg.example.com".
+
+tags = {
+  Project = "update-server"
+}

--- a/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
@@ -1,8 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
-# Copy to terraform.tfvars and edit. Real .tfvars files are gitignored, because
-# auth_config_json can carry an OAuth client secret.
+# Copy to terraform.tfvars and edit.
 
 aws_region = "us-east-1"
 ami_id     = "ami-0123456789abcdef0" # from `packer build`
@@ -14,8 +13,6 @@ gateway_hostname = "devices.example.com"
 
 # Uncomment to expose the device gateway on a non-default port.
 # gateway_port = 8443
-
-factory = "my-factory"
 
 # Set this to your Route53 zone IFF you use it for DNS. Otherwise leave this blank.
 # If this is left blank, you will have to look for the ACM certificate validation
@@ -33,21 +30,6 @@ data_volume_size = 100
 # opening port 22; leaving both empty is fine and is the default.
 # ssh_key_name     = "my-key"
 # allowed_ssh_cidr = "203.0.113.0/24"
-
-# Authentication. Leave unset for local auth with a generated admin password
-# escrowed in Secrets Manager, or provide a config as a raw JSON literal:
-#
-#   auth_config_json = <<-EOT
-#   {
-#     "Type": "github",
-#     "BaseUrl": "https://dg.example.com",
-#     "ClientId": "your-client-id",
-#     "ClientSecret": "your-client-secret"
-#   }
-#   EOT
-#
-# See docs/auth.md and contrib/auth-config-{local,github,google}.json. For OAuth
-# providers, Config.BaseUrl must be "https://dg.example.com".
 
 tags = {
   Project = "update-server"

--- a/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
@@ -12,6 +12,9 @@ ami_id     = "ami-0123456789abcdef0" # from `packer build`
 hostname         = "dg.example.com"
 gateway_hostname = "devices.example.com"
 
+# Uncomment to expose the device gateway on a non-default port.
+# gateway_port = 8443
+
 factory = "my-factory"
 
 # Set this to your Route53 zone IFF you use it for DNS. Otherwise leave this blank.

--- a/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/with-load-balancer/terraform.tfvars.example
@@ -26,6 +26,13 @@ hosted_zone_id = ""
 instance_type    = "t3.small"
 data_volume_size = 100
 
+# Uncomment to enable S3 access logging on the UI ALB. The bucket must
+# already exist and grant the ELB service account write access.
+# access_logs = {
+#   bucket = "my-alb-logs-bucket"
+#   prefix = "fioserver-ui"
+# }
+
 # Access. Prefer SSM (`aws ssm start-session --target <instance-id>`) over
 # opening port 22; leaving both empty is fine and is the default.
 # ssh_key_name     = "my-key"

--- a/contrib/terraform/aws/examples/with-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/variables.tf
@@ -1,0 +1,112 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region to deploy into."
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to resource names and tags."
+  default     = "fioserver"
+}
+
+variable "hostname" {
+  type        = string
+  description = "Public DNS name for the web UI, e.g. \"dg.example.com\"."
+}
+
+variable "gateway_hostname" {
+  type        = string
+  description = <<-EOT
+    DNS name devices use for the mTLS gateway on port 8443, e.g.
+    "devices.example.com".
+
+    Must differ from var.hostname in this topology: the UI is behind an ALB and
+    the gateway behind an NLB, and a single DNS record cannot alias to both.
+
+    This name is baked into the gateway certificate and into every enrolled
+    device's configuration, so it cannot be changed later without orphaning
+    those devices.
+  EOT
+
+  validation {
+    condition     = var.gateway_hostname != ""
+    error_message = "The gateway_hostname is required and must differ from hostname."
+  }
+}
+
+variable "factory" {
+  type        = string
+  description = "Factory name recorded in the PKI subject."
+}
+
+variable "ami_id" {
+  type        = string
+  description = "AMI built by contrib/terraform/aws/packer."
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = <<-EOT
+    Route53 zone for the certificate validation and alias records. Leave empty
+    to manage DNS yourself, but note that apply then blocks until the ACM
+    validation record exists.
+  EOT
+  default     = ""
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type."
+  default     = "t3.small"
+}
+
+variable "data_volume_size" {
+  type        = number
+  description = "Size of the persistent /data volume in GiB."
+  default     = 100
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Existing EC2 key pair, or \"\" to use SSM Session Manager only."
+  default     = ""
+}
+
+variable "allowed_ssh_cidr" {
+  type        = string
+  description = "CIDR allowed to reach port 22, or \"\" to omit the rule."
+  default     = ""
+}
+
+variable "auth_config_json" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Contents of auth-config.json, typically `file("auth-config.json")`. Leave
+    empty for local auth with a generated admin password escrowed in Secrets
+    Manager. For OAuth, Config.BaseUrl must be "https://<hostname>".
+  EOT
+  default     = ""
+}
+
+variable "tls_expiry_days" {
+  type        = number
+  description = "Gateway certificate validity. The gateway will not start once it expires."
+  default     = 3650
+}
+
+variable "snapshot_retention_days" {
+  type        = number
+  description = "Days to retain daily data-volume snapshots."
+  default     = 60
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/examples/with-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/variables.tf
@@ -21,7 +21,7 @@ variable "hostname" {
 variable "gateway_hostname" {
   type        = string
   description = <<-EOT
-    DNS name devices use for the mTLS gateway on port 8443, e.g.
+    DNS name devices use for the mTLS gateway on var.gateway_port, e.g.
     "devices.example.com".
 
     Must differ from var.hostname in this topology: the UI is behind an ALB and
@@ -36,6 +36,12 @@ variable "gateway_hostname" {
     condition     = var.gateway_hostname != ""
     error_message = "The gateway_hostname is required and must differ from hostname."
   }
+}
+
+variable "gateway_port" {
+  type        = number
+  description = "Port the device gateway's mTLS listener is reachable on."
+  default     = 8443
 }
 
 variable "factory" {

--- a/contrib/terraform/aws/examples/with-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/variables.tf
@@ -89,6 +89,19 @@ variable "snapshot_retention_days" {
   default     = 60
 }
 
+variable "access_logs" {
+  type = object({
+    bucket  = string
+    prefix  = optional(string, "")
+    enabled = optional(bool, true)
+  })
+  description = <<-EOT
+    S3 access logging for the UI ALB. The bucket must already exist and grant
+    the ELB service account write access. Leave unset (null) to disable.
+  EOT
+  default     = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags applied to every resource."

--- a/contrib/terraform/aws/examples/with-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/with-load-balancer/variables.tf
@@ -44,11 +44,6 @@ variable "gateway_port" {
   default     = 8443
 }
 
-variable "factory" {
-  type        = string
-  description = "Factory name recorded in the PKI subject."
-}
-
 variable "ami_id" {
   type        = string
   description = "AMI built by contrib/terraform/aws/packer."
@@ -86,23 +81,6 @@ variable "allowed_ssh_cidr" {
   type        = string
   description = "CIDR allowed to reach port 22, or \"\" to omit the rule."
   default     = ""
-}
-
-variable "auth_config_json" {
-  type        = string
-  sensitive   = true
-  description = <<-EOT
-    Contents of auth-config.json, typically `file("auth-config.json")`. Leave
-    empty for local auth with a generated admin password escrowed in Secrets
-    Manager. For OAuth, Config.BaseUrl must be "https://<hostname>".
-  EOT
-  default     = ""
-}
-
-variable "tls_expiry_days" {
-  type        = number
-  description = "Gateway certificate validity. The gateway will not start once it expires."
-  default     = 3650
 }
 
 variable "snapshot_retention_days" {

--- a/contrib/terraform/aws/examples/without-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/main.tf
@@ -1,0 +1,86 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Update server on a single instance, no load balancers.
+#
+# Caddy runs on the box and terminates TLS for the UI with Let's Encrypt, while
+# the device gateway is exposed directly on 8443 -- Caddy must never proxy it,
+# because the server terminates that mTLS itself.
+#
+# One Elastic IP serves both, so the UI and the gateway share a hostname. That
+# address is baked into the gateway certificate and into every enrolled device's
+# configuration, which is why the EIP is not optional here.
+#
+# DNS must resolve to the EIP before Caddy can complete the Let's Encrypt
+# HTTP-01 challenge. With hosted_zone_id set, Terraform creates that record.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  # The network module requires two AZs for load balancer compatibility even
+  # though this topology has none; only the first is used.
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name_prefix        = var.name_prefix
+  availability_zones = local.azs
+  allowed_ssh_cidr   = var.allowed_ssh_cidr
+  enable_caddy_ports = true
+  tags               = var.tags
+}
+
+module "server" {
+  source = "../../modules/server"
+
+  name_prefix       = var.name_prefix
+  hostname          = var.hostname
+  factory           = var.factory
+  ami_id            = var.ami_id
+  subnet_id         = module.network.public_subnet_ids[0]
+  availability_zone = local.azs[0]
+  security_group_id = module.network.server_security_group_id
+
+  instance_type    = var.instance_type
+  data_volume_size = var.data_volume_size
+  ssh_key_name     = var.ssh_key_name
+  auth_config_json = var.auth_config_json
+  tls_expiry_days  = var.tls_expiry_days
+
+  enable_caddy = true
+  assign_eip   = true
+
+  snapshot_retention_days = var.snapshot_retention_days
+  tags                    = var.tags
+}
+
+# No ACM certificate in this topology -- Caddy obtains its own from Let's
+# Encrypt -- so this only creates the A record pointing at the Elastic IP.
+module "dns" {
+  source = "../../modules/dns"
+
+  hostname           = var.hostname
+  hosted_zone_id     = var.hosted_zone_id
+  instance_ip        = module.server.public_ip
+  create_certificate = false
+
+  tags = var.tags
+}

--- a/contrib/terraform/aws/examples/without-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/main.tf
@@ -54,7 +54,6 @@ module "server" {
 
   name_prefix       = var.name_prefix
   hostname          = var.hostname
-  factory           = var.factory
   gateway_port      = var.gateway_port
   ami_id            = var.ami_id
   subnet_id         = module.network.public_subnet_ids[0]
@@ -64,8 +63,6 @@ module "server" {
   instance_type    = var.instance_type
   data_volume_size = var.data_volume_size
   ssh_key_name     = var.ssh_key_name
-  auth_config_json = var.auth_config_json
-  tls_expiry_days  = var.tls_expiry_days
 
   enable_caddy = true
   assign_eip   = true

--- a/contrib/terraform/aws/examples/without-load-balancer/main.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/main.tf
@@ -4,8 +4,8 @@
 # Update server on a single instance, no load balancers.
 #
 # Caddy runs on the box and terminates TLS for the UI with Let's Encrypt, while
-# the device gateway is exposed directly on 8443 -- Caddy must never proxy it,
-# because the server terminates that mTLS itself.
+# the device gateway is exposed directly on var.gateway_port (8443 by default)
+# -- Caddy must never proxy it, because the server terminates that mTLS itself.
 #
 # One Elastic IP serves both, so the UI and the gateway share a hostname. That
 # address is baked into the gateway certificate and into every enrolled device's
@@ -45,6 +45,7 @@ module "network" {
   availability_zones = local.azs
   allowed_ssh_cidr   = var.allowed_ssh_cidr
   enable_caddy_ports = true
+  gateway_port       = var.gateway_port
   tags               = var.tags
 }
 
@@ -54,6 +55,7 @@ module "server" {
   name_prefix       = var.name_prefix
   hostname          = var.hostname
   factory           = var.factory
+  gateway_port      = var.gateway_port
   ami_id            = var.ami_id
   subnet_id         = module.network.public_subnet_ids[0]
   availability_zone = local.azs[0]

--- a/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
@@ -30,8 +30,3 @@ output "secret_prefix" {
   description = "Secrets Manager prefix holding the escrowed keys."
   value       = module.server.secret_prefix
 }
-
-output "admin_password_command" {
-  description = "Retrieve the generated admin password (only when auth_config_json was empty)."
-  value       = "aws secretsmanager get-secret-value --secret-id ${module.server.secret_prefix}/admin-password --query SecretString --output text"
-}

--- a/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
@@ -1,0 +1,37 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "ui_url" {
+  description = "Web UI address, served by Caddy with a Let's Encrypt certificate."
+  value       = "https://${var.hostname}"
+}
+
+output "device_gateway_url" {
+  description = "Gateway address devices connect to, exposed directly."
+  value       = "https://${var.hostname}:8443"
+}
+
+output "public_ip" {
+  description = "Elastic IP. Point var.hostname here if managing DNS yourself."
+  value       = module.server.public_ip
+}
+
+output "instance_id" {
+  description = "Instance ID, for `aws ssm start-session --target <id>`."
+  value       = module.server.instance_id
+}
+
+output "data_volume_id" {
+  description = "Persistent data volume ID."
+  value       = module.server.data_volume_id
+}
+
+output "secret_prefix" {
+  description = "Secrets Manager prefix holding the escrowed keys."
+  value       = module.server.secret_prefix
+}
+
+output "admin_password_command" {
+  description = "Retrieve the generated admin password (only when auth_config_json was empty)."
+  value       = "aws secretsmanager get-secret-value --secret-id ${module.server.secret_prefix}/admin-password --query SecretString --output text"
+}

--- a/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/outputs.tf
@@ -8,7 +8,7 @@ output "ui_url" {
 
 output "device_gateway_url" {
   description = "Gateway address devices connect to, exposed directly."
-  value       = "https://${var.hostname}:8443"
+  value       = "https://${var.hostname}:${var.gateway_port}"
 }
 
 output "public_ip" {

--- a/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
@@ -1,8 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 #
-# Copy to terraform.tfvars and edit. Real .tfvars files are gitignored, because
-# auth_config_json can carry an OAuth client secret.
+# Copy to terraform.tfvars and edit.
 
 aws_region = "us-east-1"
 ami_id     = "ami-0123456789abcdef0" # from `packer build`
@@ -13,8 +12,6 @@ hostname = "dg.example.com"
 
 # Uncomment to expose the device gateway on a non-default port.
 # gateway_port = 8443
-
-factory = "my-factory"
 
 # Set this and Terraform creates the A record for you. Otherwise create it
 # yourself, promptly -- Let's Encrypt cannot issue until the name resolves.
@@ -27,14 +24,6 @@ data_volume_size = 100
 # opening port 22; leaving both empty is fine and is the default.
 # ssh_key_name     = "my-key"
 # allowed_ssh_cidr = "203.0.113.0/24"
-
-# Authentication. Leave unset for local auth with a generated admin password
-# escrowed in Secrets Manager, or point at a config file:
-#
-#   auth_config_json = file("auth-config.json")
-#
-# See docs/auth.md and contrib/auth-config-{local,github,google}.json. For OAuth
-# providers, Config.BaseUrl must be "https://dg.example.com".
 
 tags = {
   Project = "update-server"

--- a/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
@@ -1,0 +1,38 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Copy to terraform.tfvars and edit. Real .tfvars files are gitignored, because
+# auth_config_json can carry an OAuth client secret.
+
+aws_region = "us-east-1"
+ami_id     = "ami-0123456789abcdef0" # from `packer build`
+
+# One name serves both the UI (443) and the device gateway (8443). It must
+# resolve to the instance's Elastic IP before Caddy can get a certificate.
+hostname = "dg.example.com"
+
+factory = "my-factory"
+
+# Set this and Terraform creates the A record for you. Otherwise create it
+# yourself, promptly -- Let's Encrypt cannot issue until the name resolves.
+hosted_zone_id = "Z0123456789ABCDEFGHIJ"
+
+instance_type    = "t3.small"
+data_volume_size = 100
+
+# Access. Prefer SSM (`aws ssm start-session --target <instance-id>`) over
+# opening port 22; leaving both empty is fine and is the default.
+# ssh_key_name     = "my-key"
+# allowed_ssh_cidr = "203.0.113.0/24"
+
+# Authentication. Leave unset for local auth with a generated admin password
+# escrowed in Secrets Manager, or point at a config file:
+#
+#   auth_config_json = file("auth-config.json")
+#
+# See docs/auth.md and contrib/auth-config-{local,github,google}.json. For OAuth
+# providers, Config.BaseUrl must be "https://dg.example.com".
+
+tags = {
+  Project = "update-server"
+}

--- a/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
+++ b/contrib/terraform/aws/examples/without-load-balancer/terraform.tfvars.example
@@ -11,6 +11,9 @@ ami_id     = "ami-0123456789abcdef0" # from `packer build`
 # resolve to the instance's Elastic IP before Caddy can get a certificate.
 hostname = "dg.example.com"
 
+# Uncomment to expose the device gateway on a non-default port.
+# gateway_port = 8443
+
 factory = "my-factory"
 
 # Set this and Terraform creates the A record for you. Otherwise create it

--- a/contrib/terraform/aws/examples/without-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/variables.tf
@@ -16,8 +16,8 @@ variable "name_prefix" {
 variable "hostname" {
   type        = string
   description = <<-EOT
-    Public DNS name for both the UI (443) and the device gateway (8443), e.g.
-    "dg.example.com".
+    Public DNS name for both the UI (443) and the device gateway
+    (var.gateway_port), e.g. "dg.example.com".
 
     It must resolve to this instance's Elastic IP before Caddy can complete the
     Let's Encrypt HTTP-01 challenge. It is also baked into the gateway
@@ -29,6 +29,12 @@ variable "hostname" {
 variable "factory" {
   type        = string
   description = "Factory name recorded in the PKI subject."
+}
+
+variable "gateway_port" {
+  type        = number
+  description = "Port the device gateway's mTLS listener is reachable on."
+  default     = 8443
 }
 
 variable "ami_id" {

--- a/contrib/terraform/aws/examples/without-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/variables.tf
@@ -26,11 +26,6 @@ variable "hostname" {
   EOT
 }
 
-variable "factory" {
-  type        = string
-  description = "Factory name recorded in the PKI subject."
-}
-
 variable "gateway_port" {
   type        = number
   description = "Port the device gateway's mTLS listener is reachable on."
@@ -74,23 +69,6 @@ variable "allowed_ssh_cidr" {
   type        = string
   description = "CIDR allowed to reach port 22, or \"\" to omit the rule."
   default     = ""
-}
-
-variable "auth_config_json" {
-  type        = string
-  sensitive   = true
-  description = <<-EOT
-    Contents of auth-config.json, typically `file("auth-config.json")`. Leave
-    empty for local auth with a generated admin password escrowed in Secrets
-    Manager. For OAuth, Config.BaseUrl must be "https://<hostname>".
-  EOT
-  default     = ""
-}
-
-variable "tls_expiry_days" {
-  type        = number
-  description = "Gateway certificate validity. The gateway will not start once it expires."
-  default     = 3650
 }
 
 variable "snapshot_retention_days" {

--- a/contrib/terraform/aws/examples/without-load-balancer/variables.tf
+++ b/contrib/terraform/aws/examples/without-load-balancer/variables.tf
@@ -1,0 +1,100 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region to deploy into."
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to resource names and tags."
+  default     = "fioserver"
+}
+
+variable "hostname" {
+  type        = string
+  description = <<-EOT
+    Public DNS name for both the UI (443) and the device gateway (8443), e.g.
+    "dg.example.com".
+
+    It must resolve to this instance's Elastic IP before Caddy can complete the
+    Let's Encrypt HTTP-01 challenge. It is also baked into the gateway
+    certificate and every enrolled device's configuration, so it cannot change
+    later without orphaning those devices.
+  EOT
+}
+
+variable "factory" {
+  type        = string
+  description = "Factory name recorded in the PKI subject."
+}
+
+variable "ami_id" {
+  type        = string
+  description = "AMI built by contrib/terraform/aws/packer."
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = <<-EOT
+    Route53 zone in which to create the A record for var.hostname. Leave empty
+    to create it yourself -- but do so promptly, since Caddy cannot obtain a
+    certificate until the name resolves.
+  EOT
+  default     = ""
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type."
+  default     = "t3.small"
+}
+
+variable "data_volume_size" {
+  type        = number
+  description = "Size of the persistent /data volume in GiB."
+  default     = 100
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Existing EC2 key pair, or \"\" to use SSM Session Manager only."
+  default     = ""
+}
+
+variable "allowed_ssh_cidr" {
+  type        = string
+  description = "CIDR allowed to reach port 22, or \"\" to omit the rule."
+  default     = ""
+}
+
+variable "auth_config_json" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Contents of auth-config.json, typically `file("auth-config.json")`. Leave
+    empty for local auth with a generated admin password escrowed in Secrets
+    Manager. For OAuth, Config.BaseUrl must be "https://<hostname>".
+  EOT
+  default     = ""
+}
+
+variable "tls_expiry_days" {
+  type        = number
+  description = "Gateway certificate validity. The gateway will not start once it expires."
+  default     = 3650
+}
+
+variable "snapshot_retention_days" {
+  type        = number
+  description = "Days to retain daily data-volume snapshots."
+  default     = 60
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/modules/dns/main.tf
+++ b/contrib/terraform/aws/modules/dns/main.tf
@@ -1,0 +1,120 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# The ACM certificate for the UI, and optionally the Route53 records.
+#
+# Set hosted_zone_id and this module creates the validation records and the
+# alias records, so `terraform apply` completes unattended. Leave it empty and
+# the certificate is still requested, but apply BLOCKS in the validation step
+# until you create the CNAME by hand -- the record name and value are exposed as
+# outputs for exactly that. See the README.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+locals {
+  manage_dns = var.hosted_zone_id != ""
+
+  # Must be knowable at plan time, so it is an explicit input rather than being
+  # inferred from instance_ip -- that value is only known after the EIP exists,
+  # which would make this count unresolvable during plan.
+  want_certificate = var.create_certificate
+}
+
+# Only the UI name needs an ACM certificate: it is the ALB that terminates TLS.
+# The gateway presents its OWN certificate, minted by pki-init on the instance
+# and never seen by ACM, because the NLB passes 8443 straight through.
+resource "aws_acm_certificate" "ui" {
+  count = local.want_certificate ? 1 : 0
+
+  domain_name       = var.hostname
+  validation_method = "DNS"
+
+  tags = merge(var.tags, { Name = var.hostname })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "validation" {
+  for_each = local.manage_dns && local.want_certificate ? {
+    for dvo in aws_acm_certificate.ui[0].domain_validation_options :
+    dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id         = var.hosted_zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "ui" {
+  count = local.want_certificate ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.ui[0].arn
+  validation_record_fqdns = local.manage_dns ? [for r in aws_route53_record.validation : r.fqdn] : null
+}
+
+# The UI record. Both ports live on the same hostname -- 443 reaches the ALB and
+# 8443 the NLB -- so when load balancers are in play the A record points at the
+# ALB and a second name is used for the gateway.
+#
+# Gated on create_certificate, which is static: the LB DNS names are not known
+# until apply and so cannot drive a count.
+resource "aws_route53_record" "ui" {
+  count = local.manage_dns && local.want_certificate ? 1 : 0
+
+  zone_id = var.hosted_zone_id
+  name    = var.hostname
+  type    = "A"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# The gateway needs its own name, because a single A record cannot point at two
+# different load balancers. Devices are told this name via the TLS certificate's
+# SAN, so it must match the hostname passed to pki-init.
+resource "aws_route53_record" "gateway" {
+  count = local.manage_dns && local.want_certificate ? 1 : 0
+
+  zone_id = var.hosted_zone_id
+  name    = var.gateway_hostname == "" ? var.hostname : var.gateway_hostname
+  type    = "A"
+
+  alias {
+    name                   = var.nlb_dns_name
+    zone_id                = var.nlb_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# The Caddy topology: one address for everything, so a plain A record to the EIP.
+# Gated on create_certificate rather than on instance_ip, which is not known
+# until apply.
+resource "aws_route53_record" "direct" {
+  count = local.manage_dns && !local.want_certificate ? 1 : 0
+
+  zone_id = var.hosted_zone_id
+  name    = var.hostname
+  type    = "A"
+  ttl     = 300
+  records = [var.instance_ip]
+}

--- a/contrib/terraform/aws/modules/dns/outputs.tf
+++ b/contrib/terraform/aws/modules/dns/outputs.tf
@@ -1,0 +1,30 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "certificate_arn" {
+  description = <<-EOT
+    Validated ACM certificate ARN, or "" in the Caddy topology where no ACM
+    certificate is used. Depends on the validation resource, so consuming this
+    in a listener guarantees the certificate is issued first.
+  EOT
+  value       = local.want_certificate ? aws_acm_certificate_validation.ui[0].certificate_arn : ""
+}
+
+output "validation_records" {
+  description = <<-EOT
+    DNS validation records for the certificate. When hosted_zone_id is set these
+    are created automatically; otherwise create them by hand to unblock apply.
+  EOT
+  value = local.want_certificate ? [
+    for dvo in aws_acm_certificate.ui[0].domain_validation_options : {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  ] : []
+}
+
+output "managing_dns" {
+  description = "Whether this module is creating Route53 records."
+  value       = local.manage_dns
+}

--- a/contrib/terraform/aws/modules/dns/variables.tf
+++ b/contrib/terraform/aws/modules/dns/variables.tf
@@ -1,0 +1,83 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "hostname" {
+  type        = string
+  description = "Public DNS name for the UI; also the ACM certificate's subject."
+}
+
+variable "gateway_hostname" {
+  type        = string
+  description = <<-EOT
+    DNS name for the mTLS gateway. Required when load balancers are used, since
+    the ALB and NLB cannot share one A record. Empty means the gateway shares
+    var.hostname (correct for the Caddy topology).
+  EOT
+  default     = ""
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = <<-EOT
+    Route53 hosted zone to manage records in.
+
+    Empty means Terraform creates the ACM certificate but no records. Apply will
+    then BLOCK in aws_acm_certificate_validation until you create the CNAME
+    reported by the validation_record output. Consider a targeted apply of the
+    certificate first:
+      terraform apply -target=module.dns.aws_acm_certificate.ui
+  EOT
+  default     = ""
+}
+
+variable "create_certificate" {
+  type        = bool
+  description = <<-EOT
+    Request an ACM certificate for var.hostname. True for the load-balancer
+    topology, where the ALB terminates TLS.
+
+    False for the Caddy topology: Caddy obtains its own certificate from Let's
+    Encrypt, and requesting an unused ACM certificate would leave apply blocked
+    on a validation step nothing consumes.
+  EOT
+  default     = true
+}
+
+variable "alb_dns_name" {
+  type        = string
+  description = "ALB DNS name to alias the UI record to. Empty to skip."
+  default     = ""
+}
+
+variable "alb_zone_id" {
+  type        = string
+  description = "ALB hosted zone ID."
+  default     = ""
+}
+
+variable "nlb_dns_name" {
+  type        = string
+  description = "NLB DNS name to alias the gateway record to. Empty to skip."
+  default     = ""
+}
+
+variable "nlb_zone_id" {
+  type        = string
+  description = "NLB hosted zone ID."
+  default     = ""
+}
+
+variable "instance_ip" {
+  type        = string
+  description = <<-EOT
+    Elastic IP for a direct A record, used by the Caddy topology. Mutually
+    exclusive with the load balancer aliases.
+  EOT
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/modules/frontend/main.tf
+++ b/contrib/terraform/aws/modules/frontend/main.tf
@@ -10,9 +10,9 @@
 # port 80. An ALB sets X-Forwarded-Proto natively. Session and CSRF cookies are
 # also Secure+SameSite=Strict, so the browser-facing origin must be HTTPS.
 #
-# NLB for the device gateway (8443), TCP passthrough only. The server terminates
-# mTLS itself and needs the device's client certificate intact; terminating that
-# at an L7 proxy would discard it.
+# NLB for the device gateway (var.gateway_port), TCP passthrough only. The
+# server terminates mTLS itself and needs the device's client certificate
+# intact; terminating that at an L7 proxy would discard it.
 
 terraform {
   required_version = ">= 1.5"
@@ -127,7 +127,7 @@ resource "aws_lb" "gateway" {
 
 resource "aws_lb_target_group" "gateway" {
   name_prefix = "fio-"
-  port        = 8443
+  port        = var.gateway_port
   protocol    = "TCP"
   vpc_id      = var.vpc_id
   target_type = "ip"
@@ -152,12 +152,12 @@ resource "aws_lb_target_group" "gateway" {
 resource "aws_lb_target_group_attachment" "gateway" {
   target_group_arn = aws_lb_target_group.gateway.arn
   target_id        = var.target_ip
-  port             = 8443
+  port             = var.gateway_port
 }
 
 resource "aws_lb_listener" "gateway" {
   load_balancer_arn = aws_lb.gateway.arn
-  port              = 8443
+  port              = var.gateway_port
   protocol          = "TCP"
 
   default_action {

--- a/contrib/terraform/aws/modules/frontend/main.tf
+++ b/contrib/terraform/aws/modules/frontend/main.tf
@@ -1,0 +1,169 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Two load balancers, because the two ports have incompatible requirements.
+#
+# ALB for the UI (8080). It has to be an ALB rather than an NLB TLS listener:
+# the web UI calls its own REST API over the network, building the base URL from
+# the request scheme, and the UI port is plain HTTP. An L4 TLS listener injects
+# no headers, so the server would see "http", emit http:// URLs and self-call
+# port 80. An ALB sets X-Forwarded-Proto natively. Session and CSRF cookies are
+# also Secure+SameSite=Strict, so the browser-facing origin must be HTTPS.
+#
+# NLB for the device gateway (8443), TCP passthrough only. The server terminates
+# mTLS itself and needs the device's client certificate intact; terminating that
+# at an L7 proxy would discard it.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+locals {
+  tags = merge(var.tags, { Name = var.name_prefix })
+}
+
+# -------------------------------------------------------------------- ALB ----
+resource "aws_lb" "ui" {
+  name_prefix        = "fio-"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group_id]
+  subnets            = var.subnet_ids
+
+  idle_timeout = var.idle_timeout
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-ui" })
+}
+
+resource "aws_lb_target_group" "ui" {
+  name_prefix = "fio-"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  # IP targets rather than instance IDs: this keeps the target independent of
+  # instance replacement and avoids NLB loopback restrictions on the gateway
+  # group below.
+  target_type = "ip"
+
+  health_check {
+    # /favicon, not /. The root path is wrapped in a session check and its
+    # status depends on the configured auth provider -- 307 under noauth, 401
+    # under local auth. /favicon returns 200 unauthenticated under every
+    # provider, so the check does not have to change with the operator's auth
+    # configuration.
+    path                = "/favicon"
+    matcher             = "200"
+    protocol            = "HTTP"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-ui" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group_attachment" "ui" {
+  target_group_arn = aws_lb_target_group.ui.arn
+  target_id        = var.target_ip
+  port             = 8080
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.ui.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.ui.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = var.ssl_policy
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ui.arn
+  }
+
+  tags = local.tags
+}
+
+# -------------------------------------------------------------------- NLB ----
+resource "aws_lb" "gateway" {
+  name_prefix        = "fio-"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = var.subnet_ids
+
+  enable_cross_zone_load_balancing = true
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-gateway" })
+}
+
+resource "aws_lb_target_group" "gateway" {
+  name_prefix = "fio-"
+  port        = 8443
+  protocol    = "TCP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  # A TCP check is all that is possible here, and all that is needed: the
+  # gateway answers an unauthenticated request with 403 rather than closing the
+  # connection, so a completed handshake proves it is serving.
+  health_check {
+    protocol            = "TCP"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-gateway" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group_attachment" "gateway" {
+  target_group_arn = aws_lb_target_group.gateway.arn
+  target_id        = var.target_ip
+  port             = 8443
+}
+
+resource "aws_lb_listener" "gateway" {
+  load_balancer_arn = aws_lb.gateway.arn
+  port              = 8443
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.gateway.arn
+  }
+
+  tags = local.tags
+}

--- a/contrib/terraform/aws/modules/frontend/main.tf
+++ b/contrib/terraform/aws/modules/frontend/main.tf
@@ -38,6 +38,15 @@ resource "aws_lb" "ui" {
 
   idle_timeout = var.idle_timeout
 
+  dynamic "access_logs" {
+    for_each = var.access_logs != null ? [var.access_logs] : []
+    content {
+      bucket  = access_logs.value.bucket
+      prefix  = access_logs.value.prefix
+      enabled = access_logs.value.enabled
+    }
+  }
+
   tags = merge(local.tags, { Name = "${var.name_prefix}-ui" })
 }
 

--- a/contrib/terraform/aws/modules/frontend/outputs.tf
+++ b/contrib/terraform/aws/modules/frontend/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "alb_dns_name" {
+  description = "DNS name of the UI load balancer."
+  value       = aws_lb.ui.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Hosted zone ID of the UI load balancer, for an alias record."
+  value       = aws_lb.ui.zone_id
+}
+
+output "nlb_dns_name" {
+  description = "DNS name of the device gateway load balancer."
+  value       = aws_lb.gateway.dns_name
+}
+
+output "nlb_zone_id" {
+  description = "Hosted zone ID of the gateway load balancer, for an alias record."
+  value       = aws_lb.gateway.zone_id
+}

--- a/contrib/terraform/aws/modules/frontend/variables.tf
+++ b/contrib/terraform/aws/modules/frontend/variables.tf
@@ -53,6 +53,20 @@ variable "gateway_port" {
   default     = 8443
 }
 
+variable "access_logs" {
+  type = object({
+    bucket  = string
+    prefix  = optional(string, "")
+    enabled = optional(bool, true)
+  })
+  description = <<-EOT
+    S3 access logging for the UI ALB. The bucket must already exist and grant
+    the ELB service account write access -- Terraform does not create it.
+    Leave unset (null) to disable access logging.
+  EOT
+  default     = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags applied to every resource."

--- a/contrib/terraform/aws/modules/frontend/variables.tf
+++ b/contrib/terraform/aws/modules/frontend/variables.tf
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to resource names and tags."
+  default     = "fioserver"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC the target groups belong to."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Public subnets for the load balancers; at least two AZs."
+}
+
+variable "target_ip" {
+  type        = string
+  description = "Private IP of the update server instance."
+}
+
+variable "alb_security_group_id" {
+  type        = string
+  description = "Security group for the ALB."
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for the HTTPS listener."
+}
+
+variable "ssl_policy" {
+  type        = string
+  description = "ALB SSL policy for the HTTPS listener."
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "idle_timeout" {
+  type        = number
+  description = <<-EOT
+    ALB idle timeout in seconds. Uploading a large update through the REST API
+    can hold a connection open for a while, so this is generous by default.
+  EOT
+  default     = 300
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/modules/frontend/variables.tf
+++ b/contrib/terraform/aws/modules/frontend/variables.tf
@@ -47,6 +47,12 @@ variable "idle_timeout" {
   default     = 300
 }
 
+variable "gateway_port" {
+  type        = number
+  description = "Port the device gateway's mTLS listener is reachable on."
+  default     = 8443
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags applied to every resource."

--- a/contrib/terraform/aws/modules/network/main.tf
+++ b/contrib/terraform/aws/modules/network/main.tf
@@ -130,8 +130,8 @@ resource "aws_vpc_security_group_ingress_rule" "server_gateway" {
   security_group_id = aws_security_group.server.id
   description       = "Device gateway mTLS (server terminates TLS itself)"
   cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 8443
-  to_port           = 8443
+  from_port         = var.gateway_port
+  to_port           = var.gateway_port
   ip_protocol       = "tcp"
 }
 

--- a/contrib/terraform/aws/modules/network/main.tf
+++ b/contrib/terraform/aws/modules/network/main.tf
@@ -1,0 +1,184 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Network substrate: one VPC, two public subnets, and the security groups.
+#
+# Two subnets even though only one instance runs: an ALB requires subnets in at
+# least two availability zones. The instance lives in the first of them.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+locals {
+  tags = merge(var.tags, { Name = var.name_prefix })
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-vpc" })
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.availability_zones)
+
+  vpc_id                  = aws_vpc.main.id
+  availability_zone       = var.availability_zones[count.index]
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  map_public_ip_on_launch = !var.enable_alb_ingress
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-public-${var.availability_zones[count.index]}" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-public" })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# --------------------------------------------------------------------- ALB ----
+# Only created in the load-balancer topology; harmless otherwise, but the
+# example that does not use an ALB simply never references it.
+resource "aws_security_group" "alb" {
+  name_prefix = "${var.name_prefix}-alb-"
+  description = "Public HTTP/HTTPS ingress for the update server UI"
+  vpc_id      = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-alb" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP, redirected to HTTPS"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "Forward to the instance"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# ------------------------------------------------------------------ server ----
+resource "aws_security_group" "server" {
+  name_prefix = "${var.name_prefix}-server-"
+  description = "Update server instance"
+  vpc_id      = aws_vpc.main.id
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-server" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "server_all" {
+  security_group_id = aws_security_group.server.id
+  description       = "Outbound: GitHub releases, ACME, Secrets Manager"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# The device gateway is always exposed directly. An NLB with IP targets performs
+# no source NAT, so the client address reaching the instance is the device's own
+# -- there is no load balancer CIDR to narrow this to.
+resource "aws_vpc_security_group_ingress_rule" "server_gateway" {
+  security_group_id = aws_security_group.server.id
+  description       = "Device gateway mTLS (server terminates TLS itself)"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 8443
+  to_port           = 8443
+  ip_protocol       = "tcp"
+}
+
+# The UI port is reachable only from the ALB in the load-balancer topology. In
+# the Caddy topology nothing external reaches 8080 at all: the server binds
+# loopback and Caddy proxies to it.
+resource "aws_vpc_security_group_ingress_rule" "server_ui_from_alb" {
+  count = var.enable_alb_ingress ? 1 : 0
+
+  security_group_id            = aws_security_group.server.id
+  description                  = "UI/REST from the ALB only"
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+}
+
+# Caddy's listeners, and the HTTP-01 challenge Let's Encrypt performs against 80.
+resource "aws_vpc_security_group_ingress_rule" "server_caddy_http" {
+  count = var.enable_caddy_ports ? 1 : 0
+
+  security_group_id = aws_security_group.server.id
+  description       = "Caddy HTTP and the ACME HTTP-01 challenge"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "server_caddy_https" {
+  count = var.enable_caddy_ports ? 1 : 0
+
+  security_group_id = aws_security_group.server.id
+  description       = "Caddy HTTPS"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "server_ssh" {
+  count = var.allowed_ssh_cidr == "" ? 0 : 1
+
+  security_group_id = aws_security_group.server.id
+  description       = "SSH"
+  cidr_ipv4         = var.allowed_ssh_cidr
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}

--- a/contrib/terraform/aws/modules/network/outputs.tf
+++ b/contrib/terraform/aws/modules/network/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets, in the order the AZs were given."
+  value       = aws_subnet.public[*].id
+}
+
+output "server_security_group_id" {
+  description = "Security group attached to the update server instance."
+  value       = aws_security_group.server.id
+}
+
+output "alb_security_group_id" {
+  description = "Security group for the ALB (unused in the Caddy topology)."
+  value       = aws_security_group.alb.id
+}

--- a/contrib/terraform/aws/modules/network/variables.tf
+++ b/contrib/terraform/aws/modules/network/variables.tf
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to resource names and tags."
+  default     = "fioserver"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = <<-EOT
+    Availability zones for the public subnets. At least two are required: an
+    ALB will not launch into a single AZ, even though only one instance runs.
+  EOT
+
+  validation {
+    condition     = length(var.availability_zones) >= 2
+    error_message = "At least two availability zones are required for the load balancers."
+  }
+}
+
+variable "allowed_ssh_cidr" {
+  type        = string
+  description = <<-EOT
+    CIDR permitted to reach port 22. Set to "" to omit the rule entirely and
+    rely on SSM Session Manager, which is the recommended access path.
+  EOT
+  default     = ""
+}
+
+variable "enable_alb_ingress" {
+  type        = bool
+  description = "Allow the ALB security group to reach the instance's UI port."
+  default     = false
+}
+
+variable "enable_caddy_ports" {
+  type        = bool
+  description = "Open 80/443 for Caddy and its ACME HTTP-01 challenge."
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/modules/network/variables.tf
+++ b/contrib/terraform/aws/modules/network/variables.tf
@@ -47,6 +47,12 @@ variable "enable_caddy_ports" {
   default     = false
 }
 
+variable "gateway_port" {
+  type        = number
+  description = "Port the device gateway's mTLS listener is reachable on."
+  default     = 8443
+}
+
 variable "tags" {
   type        = map(string)
   description = "Extra tags applied to every resource."

--- a/contrib/terraform/aws/modules/server/main.tf
+++ b/contrib/terraform/aws/modules/server/main.tf
@@ -180,7 +180,7 @@ resource "aws_instance" "server" {
           FIOSERVER_SECRET_PREFIX=${local.secret_prefix}
           FIOSERVER_TLS_EXPIRY_DAYS=${var.tls_expiry_days}
           FIOSERVER_UI_ADDR=${local.ui_addr}
-          FIOSERVER_GATEWAY_ADDR=0.0.0.0:8443
+          FIOSERVER_GATEWAY_ADDR=0.0.0.0:${var.gateway_port}
           AWS_REGION=${data.aws_region.current.name}
     runcmd:
       - [systemctl, enable, --now, fioserver-volume-init.service]

--- a/contrib/terraform/aws/modules/server/main.tf
+++ b/contrib/terraform/aws/modules/server/main.tf
@@ -18,15 +18,12 @@ data "aws_region" "current" {}
 locals {
   tags = merge(var.tags, { Name = var.name_prefix })
 
-  # The gateway certificate's SAN, and therefore what pki-init is given. Falls
-  # back to the UI hostname when one address serves both.
-  gateway_hostname = var.gateway_hostname == "" ? var.hostname : var.gateway_hostname
-
   secret_prefix = "${var.name_prefix}/${var.hostname}"
 
-  # Written by the instance on first boot, never by Terraform. Declared here so
-  # the IAM policy can name them explicitly rather than using a wildcard.
-  escrowed_secrets = ["hmac-secret", "certs-archive", "tuf-archive", "admin-password"]
+  # Written by scripts/init-secrets.sh, never by Terraform or the instance.
+  # Declared here so the IAM policy can name them explicitly rather than
+  # using a wildcard.
+  escrowed_secrets = ["hmac-secret", "certs-archive", "tuf-archive"]
 
   # With an ALB in front the instance must accept connections over the network;
   # with Caddy on the box, loopback is enough and keeps 8080 unreachable.
@@ -63,36 +60,19 @@ resource "aws_volume_attachment" "data" {
 }
 
 # ---------------------------------------------------------------- secrets ----
-resource "aws_secretsmanager_secret" "auth_config" {
-  name        = "${local.secret_prefix}/auth-config"
-  description = "auth-config.json for the update server"
-
-  recovery_window_in_days = var.secret_recovery_window_days
-  tags                    = local.tags
+# Terraform never creates these -- scripts/init-secrets.sh does, before
+# `apply` runs. Looking them up with a data source (rather than owning them
+# as a resource) means a deployment that skips the script fails fast here,
+# at plan/apply time, instead of succeeding and leaving the instance to fail
+# loudly at boot.
+data "aws_secretsmanager_secret" "auth_config" {
+  name = "${local.secret_prefix}/auth-config"
 }
 
-# The only secret Terraform populates. If auth_config_json is empty the instance
-# generates a local-auth config on first boot and escrows it here itself, which
-# is why ignore_changes is set: a later apply must not clobber that.
-resource "aws_secretsmanager_secret_version" "auth_config" {
-  count = var.auth_config_json == "" ? 0 : 1
-
-  secret_id     = aws_secretsmanager_secret.auth_config.id
-  secret_string = var.auth_config_json
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
-}
-
-resource "aws_secretsmanager_secret" "escrow" {
+data "aws_secretsmanager_secret" "escrow" {
   for_each = toset(local.escrowed_secrets)
 
-  name        = "${local.secret_prefix}/${each.key}"
-  description = "Written by the instance on first boot: ${each.key}"
-
-  recovery_window_in_days = var.secret_recovery_window_days
-  tags                    = local.tags
+  name = "${local.secret_prefix}/${each.key}"
 }
 
 # -------------------------------------------------------------------- IAM ----
@@ -114,17 +94,17 @@ resource "aws_iam_role" "server" {
 
 data "aws_iam_policy_document" "server" {
   # Scoped to exactly the five secrets this deployment owns, not a prefix
-  # wildcard.
+  # wildcard. Read-only: the instance only ever restores from escrow (see
+  # fioserver-bootstrap.sh's State B); Escrow is populated by init-secrets.sh.
   statement {
     sid = "SecretEscrow"
     actions = [
       "secretsmanager:GetSecretValue",
-      "secretsmanager:PutSecretValue",
       "secretsmanager:DescribeSecret",
     ]
     resources = concat(
-      [aws_secretsmanager_secret.auth_config.arn],
-      [for s in aws_secretsmanager_secret.escrow : s.arn],
+      [data.aws_secretsmanager_secret.auth_config.arn],
+      [for s in data.aws_secretsmanager_secret.escrow : s.arn],
     )
   }
 
@@ -175,10 +155,7 @@ resource "aws_instance" "server" {
         permissions: '0644'
         content: |
           FIOSERVER_HOSTNAME=${var.hostname}
-          FIOSERVER_GATEWAY_HOSTNAME=${local.gateway_hostname}
-          FIOSERVER_FACTORY=${var.factory}
           FIOSERVER_SECRET_PREFIX=${local.secret_prefix}
-          FIOSERVER_TLS_EXPIRY_DAYS=${var.tls_expiry_days}
           FIOSERVER_UI_ADDR=${local.ui_addr}
           FIOSERVER_GATEWAY_ADDR=0.0.0.0:${var.gateway_port}
           AWS_REGION=${data.aws_region.current.name}

--- a/contrib/terraform/aws/modules/server/main.tf
+++ b/contrib/terraform/aws/modules/server/main.tf
@@ -1,0 +1,285 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# The instance, its persistent data volume, the secret escrow, and backups.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+data "aws_region" "current" {}
+
+locals {
+  tags = merge(var.tags, { Name = var.name_prefix })
+
+  # The gateway certificate's SAN, and therefore what pki-init is given. Falls
+  # back to the UI hostname when one address serves both.
+  gateway_hostname = var.gateway_hostname == "" ? var.hostname : var.gateway_hostname
+
+  secret_prefix = "${var.name_prefix}/${var.hostname}"
+
+  # Written by the instance on first boot, never by Terraform. Declared here so
+  # the IAM policy can name them explicitly rather than using a wildcard.
+  escrowed_secrets = ["hmac-secret", "certs-archive", "tuf-archive", "admin-password"]
+
+  # With an ALB in front the instance must accept connections over the network;
+  # with Caddy on the box, loopback is enough and keeps 8080 unreachable.
+  ui_addr = var.enable_caddy ? "127.0.0.1:8080" : "0.0.0.0:8080"
+}
+
+# ------------------------------------------------------------ data volume ----
+# A standalone volume, deliberately not a root block device, so the server's
+# state survives replacing the instance. There is no prevent_destroy: it would
+# make `terraform destroy` fail and strand the volume. The DLM snapshots and the
+# secret escrow are the recovery path -- see the README.
+resource "aws_ebs_volume" "data" {
+  availability_zone = var.availability_zone
+  size              = var.data_volume_size
+  type              = "gp3"
+  encrypted         = true
+
+  tags = merge(local.tags, {
+    Name = "${var.name_prefix}-data"
+    # The DLM policy selects the volume by this tag.
+    fioserver-backup = var.name_prefix
+  })
+}
+
+resource "aws_volume_attachment" "data" {
+  # Requested as /dev/sdf, but Nitro instances expose it as /dev/nvme1n1. The
+  # instance never refers to either: it mounts by filesystem label.
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.server.id
+
+  # Do not force-detach a mounted filesystem when replacing the instance.
+  skip_destroy = true
+}
+
+# ---------------------------------------------------------------- secrets ----
+resource "aws_secretsmanager_secret" "auth_config" {
+  name        = "${local.secret_prefix}/auth-config"
+  description = "auth-config.json for the update server"
+
+  recovery_window_in_days = var.secret_recovery_window_days
+  tags                    = local.tags
+}
+
+# The only secret Terraform populates. If auth_config_json is empty the instance
+# generates a local-auth config on first boot and escrows it here itself, which
+# is why ignore_changes is set: a later apply must not clobber that.
+resource "aws_secretsmanager_secret_version" "auth_config" {
+  count = var.auth_config_json == "" ? 0 : 1
+
+  secret_id     = aws_secretsmanager_secret.auth_config.id
+  secret_string = var.auth_config_json
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret" "escrow" {
+  for_each = toset(local.escrowed_secrets)
+
+  name        = "${local.secret_prefix}/${each.key}"
+  description = "Written by the instance on first boot: ${each.key}"
+
+  recovery_window_in_days = var.secret_recovery_window_days
+  tags                    = local.tags
+}
+
+# -------------------------------------------------------------------- IAM ----
+data "aws_iam_policy_document" "assume_ec2" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "server" {
+  name_prefix        = "${var.name_prefix}-server-"
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "server" {
+  # Scoped to exactly the five secrets this deployment owns, not a prefix
+  # wildcard.
+  statement {
+    sid = "SecretEscrow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:DescribeSecret",
+    ]
+    resources = concat(
+      [aws_secretsmanager_secret.auth_config.arn],
+      [for s in aws_secretsmanager_secret.escrow : s.arn],
+    )
+  }
+
+  statement {
+    sid       = "DescribeVolumes"
+    actions   = ["ec2:DescribeVolumes", "ec2:DescribeTags"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "server" {
+  name_prefix = "${var.name_prefix}-server-"
+  role        = aws_iam_role.server.id
+  policy      = data.aws_iam_policy_document.server.json
+}
+
+# Session Manager access, so the read-only root and the shared SSH host keys do
+# not force port 22 open.
+resource "aws_iam_role_policy_attachment" "ssm" {
+  count = var.enable_ssm ? 1 : 0
+
+  role       = aws_iam_role.server.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "server" {
+  name_prefix = "${var.name_prefix}-server-"
+  role        = aws_iam_role.server.name
+  tags        = local.tags
+}
+
+# --------------------------------------------------------------- instance ----
+resource "aws_instance" "server" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+  iam_instance_profile   = aws_iam_instance_profile.server.name
+  key_name               = var.ssh_key_name == "" ? null : var.ssh_key_name
+
+  # Configuration only -- never secrets. The instance fetches those from Secrets
+  # Manager using its instance profile, so nothing sensitive lands in user_data
+  # (which is readable via IMDS) or in Terraform state.
+  user_data = <<-EOT
+    #cloud-config
+    write_files:
+      - path: /etc/fioserver/env
+        permissions: '0644'
+        content: |
+          FIOSERVER_HOSTNAME=${var.hostname}
+          FIOSERVER_GATEWAY_HOSTNAME=${local.gateway_hostname}
+          FIOSERVER_FACTORY=${var.factory}
+          FIOSERVER_SECRET_PREFIX=${local.secret_prefix}
+          FIOSERVER_TLS_EXPIRY_DAYS=${var.tls_expiry_days}
+          FIOSERVER_UI_ADDR=${local.ui_addr}
+          FIOSERVER_GATEWAY_ADDR=0.0.0.0:8443
+          AWS_REGION=${data.aws_region.current.name}
+    runcmd:
+      - [systemctl, enable, --now, fioserver-volume-init.service]
+      - [systemctl, enable, --now, data.mount]
+      - [systemctl, enable, --now, fioserver-bootstrap.service]
+      - [systemctl, enable, --now, fioserver.service]
+%{if var.enable_caddy~}
+      - [systemctl, enable, --now, caddy.service]
+%{endif~}
+  EOT
+
+  # A config change should not silently destroy the instance and its state.
+  user_data_replace_on_change = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    volume_size           = var.root_volume_size
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-server" })
+
+  lifecycle {
+    # Rebuilding the AMI is the OS patching path; adopt a new one only when the
+    # operator explicitly replaces the instance.
+    ignore_changes = [ami]
+  }
+}
+
+resource "aws_eip" "server" {
+  count = var.assign_eip ? 1 : 0
+
+  instance = aws_instance.server.id
+  domain   = "vpc"
+
+  tags = merge(local.tags, { Name = "${var.name_prefix}-eip" })
+}
+
+# --------------------------------------------------------------- backups ----
+# DLM needs a service role. The console creates AWSDataLifecycleManagerDefaultRole
+# implicitly, but the API never does -- so on a fresh account relying on it makes
+# apply fail. Create our own.
+data "aws_iam_policy_document" "assume_dlm" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["dlm.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "dlm" {
+  name_prefix        = "${var.name_prefix}-dlm-"
+  assume_role_policy = data.aws_iam_policy_document.assume_dlm.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "dlm" {
+  role       = aws_iam_role.dlm.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "data" {
+  description        = "Daily snapshots of the ${var.name_prefix} data volume"
+  execution_role_arn = aws_iam_role.dlm.arn
+  state              = "ENABLED"
+  tags               = local.tags
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    target_tags = {
+      fioserver-backup = var.name_prefix
+    }
+
+    schedule {
+      name = "daily"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = [var.snapshot_start_time]
+      }
+
+      retain_rule {
+        interval      = var.snapshot_retention_days
+        interval_unit = "DAYS"
+      }
+
+      # Note: these snapshots are crash-consistent. SQLite in WAL mode recovers
+      # from them in practice, but see the README for the caveat.
+      copy_tags = true
+    }
+  }
+}

--- a/contrib/terraform/aws/modules/server/outputs.tf
+++ b/contrib/terraform/aws/modules/server/outputs.tf
@@ -27,10 +27,10 @@ output "secret_prefix" {
 }
 
 output "secret_arns" {
-  description = "ARNs of every secret this deployment owns."
+  description = "ARNs of every secret this deployment reads from Secrets Manager."
   value = merge(
-    { auth-config = aws_secretsmanager_secret.auth_config.arn },
-    { for k, s in aws_secretsmanager_secret.escrow : k => s.arn },
+    { auth-config = data.aws_secretsmanager_secret.auth_config.arn },
+    { for k, s in data.aws_secretsmanager_secret.escrow : k => s.arn },
   )
 }
 

--- a/contrib/terraform/aws/modules/server/outputs.tf
+++ b/contrib/terraform/aws/modules/server/outputs.tf
@@ -1,0 +1,40 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+output "instance_id" {
+  description = "ID of the update server instance."
+  value       = aws_instance.server.id
+}
+
+output "private_ip" {
+  description = "Private IP, used as the load balancer target."
+  value       = aws_instance.server.private_ip
+}
+
+output "public_ip" {
+  description = "Public address: the Elastic IP when one is assigned."
+  value       = var.assign_eip ? aws_eip.server[0].public_ip : aws_instance.server.public_ip
+}
+
+output "data_volume_id" {
+  description = "ID of the persistent data volume."
+  value       = aws_ebs_volume.data.id
+}
+
+output "secret_prefix" {
+  description = "Secrets Manager name prefix for this deployment."
+  value       = local.secret_prefix
+}
+
+output "secret_arns" {
+  description = "ARNs of every secret this deployment owns."
+  value = merge(
+    { auth-config = aws_secretsmanager_secret.auth_config.arn },
+    { for k, s in aws_secretsmanager_secret.escrow : k => s.arn },
+  )
+}
+
+output "iam_role_name" {
+  description = "Name of the instance's IAM role."
+  value       = aws_iam_role.server.name
+}

--- a/contrib/terraform/aws/modules/server/variables.tf
+++ b/contrib/terraform/aws/modules/server/variables.tf
@@ -15,30 +15,6 @@ variable "hostname" {
   EOT
 }
 
-variable "gateway_hostname" {
-  type        = string
-  description = <<-EOT
-    DNS name devices use for the mTLS gateway on var.gateway_port. Leave empty
-    to use var.hostname, which is correct when one address serves both (the
-    Caddy topology).
-
-    With load balancers this MUST be a distinct name: the UI is fronted by an
-    ALB and the gateway by an NLB, and a single DNS record cannot alias to both.
-
-    This value is passed to `pki-init --dnsname` and becomes the first DNS SAN
-    of the gateway certificate. The server derives every device-facing URL from
-    it, and each enrolled device stores those URLs in its sota.toml -- so it is
-    effectively immutable once a device has enrolled. Changing it orphans
-    existing devices.
-  EOT
-  default     = ""
-}
-
-variable "factory" {
-  type        = string
-  description = "Factory name recorded in the PKI subject (`pki-init --factory`)."
-}
-
 variable "ami_id" {
   type        = string
   description = "AMI built by contrib/terraform/aws/packer."
@@ -83,37 +59,6 @@ variable "ssh_key_name" {
   default     = ""
 }
 
-variable "auth_config_json" {
-  type        = string
-  sensitive   = true
-  description = <<-EOT
-    Contents of auth-config.json, typically `file("auth-config.json")`. See
-    docs/auth.md and contrib/auth-config-{local,github,google}.json; for OAuth
-    providers, Config.BaseUrl must be "https://<hostname>".
-
-    Leave empty to have the instance configure local auth on first boot and
-    escrow a generated admin password in Secrets Manager.
-
-    Note: a value set here is stored in Terraform state. To keep an OAuth client
-    secret out of state, leave this empty and populate the auth-config secret
-    out of band with `aws secretsmanager put-secret-value`.
-  EOT
-  default     = ""
-}
-
-variable "tls_expiry_days" {
-  type        = number
-  description = <<-EOT
-    Validity of the gateway TLS certificate, in days.
-
-    Deliberately long. The gateway REFUSES TO START once this certificate
-    expires, and nothing renews it automatically -- Caddy's Let's Encrypt
-    automation covers only the UI port. `pki-init` itself defaults to 365, which
-    would turn a working deployment into a hard failure a year later.
-  EOT
-  default     = 3650
-}
-
 variable "gateway_port" {
   type        = number
   description = "Port the device gateway's mTLS listener binds and is reachable on."
@@ -152,16 +97,6 @@ variable "snapshot_start_time" {
   type        = string
   description = "UTC time of day for the daily snapshot, as HH:MM."
   default     = "05:17"
-}
-
-variable "secret_recovery_window_days" {
-  type        = number
-  description = <<-EOT
-    Secrets Manager recovery window. Note that a non-zero value means a
-    destroyed stack leaves secrets pending deletion, and re-applying with the
-    same name fails until they are purged or restored.
-  EOT
-  default     = 7
 }
 
 variable "tags" {

--- a/contrib/terraform/aws/modules/server/variables.tf
+++ b/contrib/terraform/aws/modules/server/variables.tf
@@ -18,9 +18,9 @@ variable "hostname" {
 variable "gateway_hostname" {
   type        = string
   description = <<-EOT
-    DNS name devices use for the mTLS gateway on port 8443. Leave empty to use
-    var.hostname, which is correct when one address serves both (the Caddy
-    topology).
+    DNS name devices use for the mTLS gateway on var.gateway_port. Leave empty
+    to use var.hostname, which is correct when one address serves both (the
+    Caddy topology).
 
     With load balancers this MUST be a distinct name: the UI is fronted by an
     ALB and the gateway by an NLB, and a single DNS record cannot alias to both.
@@ -112,6 +112,12 @@ variable "tls_expiry_days" {
     would turn a working deployment into a hard failure a year later.
   EOT
   default     = 3650
+}
+
+variable "gateway_port" {
+  type        = number
+  description = "Port the device gateway's mTLS listener binds and is reachable on."
+  default     = 8443
 }
 
 variable "enable_caddy" {

--- a/contrib/terraform/aws/modules/server/variables.tf
+++ b/contrib/terraform/aws/modules/server/variables.tf
@@ -1,0 +1,165 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to resource names and tags."
+  default     = "fioserver"
+}
+
+variable "hostname" {
+  type        = string
+  description = <<-EOT
+    Public DNS name browsers use for the UI, e.g. "dg.example.com". Also the
+    name the UI resolves to loopback for its own internal API calls.
+  EOT
+}
+
+variable "gateway_hostname" {
+  type        = string
+  description = <<-EOT
+    DNS name devices use for the mTLS gateway on port 8443. Leave empty to use
+    var.hostname, which is correct when one address serves both (the Caddy
+    topology).
+
+    With load balancers this MUST be a distinct name: the UI is fronted by an
+    ALB and the gateway by an NLB, and a single DNS record cannot alias to both.
+
+    This value is passed to `pki-init --dnsname` and becomes the first DNS SAN
+    of the gateway certificate. The server derives every device-facing URL from
+    it, and each enrolled device stores those URLs in its sota.toml -- so it is
+    effectively immutable once a device has enrolled. Changing it orphans
+    existing devices.
+  EOT
+  default     = ""
+}
+
+variable "factory" {
+  type        = string
+  description = "Factory name recorded in the PKI subject (`pki-init --factory`)."
+}
+
+variable "ami_id" {
+  type        = string
+  description = "AMI built by contrib/terraform/aws/packer."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet to launch the instance in."
+}
+
+variable "availability_zone" {
+  type        = string
+  description = "AZ for the data volume; must match the subnet's AZ."
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group for the instance."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type."
+  default     = "t3.small"
+}
+
+variable "root_volume_size" {
+  type        = number
+  description = "Root volume size in GiB. Holds only the OS; state lives on /data."
+  default     = 8
+}
+
+variable "data_volume_size" {
+  type        = number
+  description = "Size of the persistent /data volume in GiB."
+  default     = 100
+}
+
+variable "ssh_key_name" {
+  type        = string
+  description = "Existing EC2 key pair name, or \"\" to rely on SSM only."
+  default     = ""
+}
+
+variable "auth_config_json" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Contents of auth-config.json, typically `file("auth-config.json")`. See
+    docs/auth.md and contrib/auth-config-{local,github,google}.json; for OAuth
+    providers, Config.BaseUrl must be "https://<hostname>".
+
+    Leave empty to have the instance configure local auth on first boot and
+    escrow a generated admin password in Secrets Manager.
+
+    Note: a value set here is stored in Terraform state. To keep an OAuth client
+    secret out of state, leave this empty and populate the auth-config secret
+    out of band with `aws secretsmanager put-secret-value`.
+  EOT
+  default     = ""
+}
+
+variable "tls_expiry_days" {
+  type        = number
+  description = <<-EOT
+    Validity of the gateway TLS certificate, in days.
+
+    Deliberately long. The gateway REFUSES TO START once this certificate
+    expires, and nothing renews it automatically -- Caddy's Let's Encrypt
+    automation covers only the UI port. `pki-init` itself defaults to 365, which
+    would turn a working deployment into a hard failure a year later.
+  EOT
+  default     = 3650
+}
+
+variable "enable_caddy" {
+  type        = bool
+  description = "Run Caddy on the instance for TLS (the no-load-balancer topology)."
+  default     = false
+}
+
+variable "assign_eip" {
+  type        = bool
+  description = <<-EOT
+    Attach an Elastic IP. Required for the Caddy topology: the address is baked
+    into the TLS certificate and into every device's configuration, so it must
+    not change when the instance stops.
+  EOT
+  default     = false
+}
+
+variable "enable_ssm" {
+  type        = bool
+  description = "Attach AmazonSSMManagedInstanceCore for Session Manager access."
+  default     = true
+}
+
+variable "snapshot_retention_days" {
+  type        = number
+  description = "Days to retain daily data-volume snapshots before deletion."
+  default     = 60
+}
+
+variable "snapshot_start_time" {
+  type        = string
+  description = "UTC time of day for the daily snapshot, as HH:MM."
+  default     = "05:17"
+}
+
+variable "secret_recovery_window_days" {
+  type        = number
+  description = <<-EOT
+    Secrets Manager recovery window. Note that a non-zero value means a
+    destroyed stack leaves secrets pending deletion, and re-applying with the
+    same name fails until they are purged or restored.
+  EOT
+  default     = 7
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Extra tags applied to every resource."
+  default     = {}
+}

--- a/contrib/terraform/aws/packer/files/Caddyfile
+++ b/contrib/terraform/aws/packer/files/Caddyfile
@@ -1,0 +1,20 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Caddy fronts the UI in the no-load-balancer topology, terminating TLS with
+# Let's Encrypt on 80/443 and proxying to the plain-HTTP UI port.
+#
+# Caddy must never touch 8443: the device gateway terminates its own mTLS and
+# needs the client certificate intact.
+#
+# reverse_proxy sets X-Forwarded-Proto automatically, which the UI needs -- it
+# builds its own API base URL from the request scheme, so without that header it
+# would emit http:// links and call itself over plain HTTP.
+{
+	admin off
+}
+
+{$FIOSERVER_HOSTNAME} {
+	encode gzip
+	reverse_proxy 127.0.0.1:8080
+}

--- a/contrib/terraform/aws/packer/files/data.mount
+++ b/contrib/terraform/aws/packer/files/data.mount
@@ -1,0 +1,20 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Mount the persistent data volume by LABEL rather than device path: the volume
+# is attached as /dev/sdf but appears as /dev/nvme1n1 on Nitro instances, and the
+# number can shift. The label is set once by fioserver-volume-init.
+
+[Unit]
+Description=fioserver data volume
+Requires=fioserver-volume-init.service
+After=fioserver-volume-init.service
+
+[Mount]
+What=/dev/disk/by-label/fiodata
+Where=/data
+Type=ext4
+Options=defaults,noatime
+
+[Install]
+WantedBy=local-fs.target

--- a/contrib/terraform/aws/packer/files/fioserver-bootstrap.service
+++ b/contrib/terraform/aws/packer/files/fioserver-bootstrap.service
@@ -1,0 +1,25 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# One-shot bootstrap that decides between "already provisioned", "restore from
+# the Secrets Manager escrow" and "initialize a new server". It runs on every
+# boot and is idempotent; see the script for why the ordering of those tests
+# matters.
+
+[Unit]
+Description=Bootstrap the fioserver datadir
+Requires=data.mount
+After=data.mount network-online.target
+Wants=network-online.target
+Before=fioserver.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/fioserver/env
+ExecStart=/usr/local/sbin/fioserver-bootstrap
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/terraform/aws/packer/files/fioserver-bootstrap.sh
+++ b/contrib/terraform/aws/packer/files/fioserver-bootstrap.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# First-boot bootstrap for the update server.
+#
+# Runs on EVERY boot (systemd oneshot) and picks one of three states. Choosing
+# the wrong state is the worst thing this script can do: re-running the init
+# commands on an already-provisioned server would mint a NEW TUF root key and
+# orphan every enrolled device. So the ordering of these tests matters, and the
+# cheapest, most local evidence (files on the data volume) is checked first.
+#
+#   State A  the data volume already holds a provisioned datadir  -> do nothing
+#   State B  the datadir is empty but secrets are escrowed        -> restore
+#   State C  no datadir and no escrow                             -> initialize
+#
+# Bootstrap ordering is dictated by the server itself:
+#   * auth-init writes ONLY auth/hmac.secret and no auth-config.json, and serve
+#     then fails in auth.NewProvider -> GetAuthConfig. So an auth-config.json
+#     must be supplied separately; that is what the auth-config secret is for.
+#   * InitHmacSecret() errors if auth/hmac.secret already exists.
+#   * tuf-init requires the HMAC secret to pre-exist (the TUF role keys are
+#     encrypted with a key derived from it via HKDF).
+#   * pki-init calls AssertCleanPki() and errors if ANY file in certs/ exists.
+# Each step below is therefore guarded by its own file test, so a crash midway
+# through State C leaves a resumable datadir rather than a wedged one.
+
+set -euo pipefail
+
+DATADIR=/data
+ENV_FILE=/etc/fioserver/env
+FIOSERVER=/usr/local/bin/fioserver
+MARKER="${DATADIR}/.bootstrap-state"
+
+log() { echo "bootstrap: $*"; }
+die() { echo "bootstrap: ERROR: $*" >&2; exit 1; }
+
+[ -r "$ENV_FILE" ] || die "missing $ENV_FILE (should be written by user_data)"
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+
+: "${FIOSERVER_HOSTNAME:?must be set in $ENV_FILE}"
+: "${FIOSERVER_FACTORY:?must be set in $ENV_FILE}"
+: "${FIOSERVER_SECRET_PREFIX:?must be set in $ENV_FILE}"
+: "${AWS_REGION:?must be set in $ENV_FILE}"
+TLS_EXPIRY_DAYS="${FIOSERVER_TLS_EXPIRY_DAYS:-3650}"
+
+# Devices reach the gateway by a name that may differ from the UI's: with load
+# balancers the UI is behind an ALB and the gateway behind an NLB, and one DNS
+# record cannot alias to both. This is the name that goes into the certificate.
+GATEWAY_HOSTNAME="${FIOSERVER_GATEWAY_HOSTNAME:-$FIOSERVER_HOSTNAME}"
+
+export AWS_DEFAULT_REGION="$AWS_REGION"
+
+secret_id() { echo "${FIOSERVER_SECRET_PREFIX}/$1"; }
+
+# Print a secret's value, or nothing if it is absent/empty. A missing secret is
+# a normal, expected condition here (it is how State C is detected), so this
+# must not trip `set -e`.
+secret_get() {
+    aws secretsmanager get-secret-value \
+        --secret-id "$(secret_id "$1")" \
+        --query SecretString --output text 2>/dev/null || true
+}
+
+# Secrets Manager caps a secret at 64 KiB. certs/ and tuf/ hold only keys,
+# certificates and TUF metadata, so they are far below that -- but fail loudly
+# rather than let AWS truncate an escrow we may later need to restore from.
+secret_put() {
+    local name="$1" file="$2" size
+    size=$(wc -c <"$file")
+    if [ "$size" -gt 65536 ]; then
+        die "$name is ${size} bytes, over the 64KiB Secrets Manager limit"
+    fi
+    # file:// (not fileb://) -- these payloads are already base64 ASCII, and
+    # passing them via a file keeps them off the process command line.
+    aws secretsmanager put-secret-value \
+        --secret-id "$(secret_id "$name")" \
+        --secret-string "file://${file}" >/dev/null
+    log "escrowed $name (${size} bytes)"
+}
+
+mountpoint -q "$DATADIR" || die "$DATADIR is not a mount point"
+
+# ---------------------------------------------------------------- State A ----
+# Both the TUF root key and the HMAC secret that decrypts it are present, so
+# this datadir is provisioned. Never touch it.
+if [ -f "${DATADIR}/tuf/keys/root.key" ] && [ -f "${DATADIR}/auth/hmac.secret" ]; then
+    log "datadir already provisioned; nothing to do"
+    echo "A $(date -u +%FT%TZ)" >"$MARKER"
+    exit 0
+fi
+
+# ---------------------------------------------------------------- State B ----
+# Empty volume, but an escrow exists: this is a replacement instance or a
+# rebuild onto a fresh volume. Restore rather than re-initialize, so the
+# factory identity and every enrolled device survive.
+HMAC_B64="$(secret_get hmac-secret)"
+if [ -n "$HMAC_B64" ]; then
+    log "escrow found; restoring PKI and TUF state from Secrets Manager"
+    install -d -m 0750 "${DATADIR}/auth" "${DATADIR}/certs" "${DATADIR}/tuf"
+
+    # The HMAC secret is 64 bytes of raw binary, so it is escrowed base64-encoded.
+    umask 077
+    echo "$HMAC_B64" | base64 -d >"${DATADIR}/auth/hmac.secret"
+    chmod 0600 "${DATADIR}/auth/hmac.secret"
+
+    AUTH_CONFIG="$(secret_get auth-config)"
+    if [ -n "$AUTH_CONFIG" ]; then
+        printf '%s' "$AUTH_CONFIG" >"${DATADIR}/auth/auth-config.json"
+    else
+        # Terraform only seeds this secret when the operator supplied
+        # auth_config_json. If it is empty, State C generated the config
+        # locally and escrowed it -- so an empty secret here means the escrow
+        # is incomplete, not that local auth was intended.
+        die "auth-config secret is empty; cannot restore"
+    fi
+    chmod 0640 "${DATADIR}/auth/auth-config.json"
+
+    # The archives are created with `tar -C $DATADIR certs` / `... tuf`, so
+    # their entries are already prefixed with the directory name. Extract at
+    # the datadir root, not into the directory itself.
+    for name in certs-archive tuf-archive; do
+        val="$(secret_get "$name")"
+        [ -n "$val" ] || die "$name secret is empty; cannot restore"
+        echo "$val" | base64 -d | tar -xzf - -C "$DATADIR"
+        log "restored $name"
+    done
+
+    # Re-assert restrictive modes: tar preserves them, but a hand-edited escrow
+    # might not.
+    find "${DATADIR}/certs" "${DATADIR}/tuf" -type f -name '*.key' -exec chmod 0600 {} +
+
+    # Deliberately NOT restored: db.sqlite. The escrow preserves the server's
+    # identity, not its data. If the volume was lost, recover the database from
+    # a DLM snapshot; otherwise device and update records are gone even though
+    # the PKI is intact.
+    log "restore complete (db.sqlite not restored; see the README)"
+    echo "B $(date -u +%FT%TZ)" >"$MARKER"
+    exit 0
+fi
+
+# ---------------------------------------------------------------- State C ----
+# Genuinely first boot.
+log "no datadir and no escrow; initializing a new server"
+
+if [ ! -f "${DATADIR}/auth/hmac.secret" ]; then
+    log "running auth-init"
+    "$FIOSERVER" --datadir "$DATADIR" auth-init
+fi
+
+if [ ! -f "${DATADIR}/auth/auth-config.json" ]; then
+    AUTH_CONFIG="$(secret_get auth-config)"
+    if [ -n "$AUTH_CONFIG" ]; then
+        log "writing operator-supplied auth-config.json"
+        printf '%s' "$AUTH_CONFIG" >"${DATADIR}/auth/auth-config.json"
+        chmod 0640 "${DATADIR}/auth/auth-config.json"
+    else
+        log "no auth-config supplied; configuring local auth with a generated admin"
+        cat >"${DATADIR}/auth/auth-config.json" <<'EOF'
+{
+  "Type": "local",
+  "SessionTimeoutHours": 48,
+  "Config": {
+    "MinPasswordLength": 12,
+    "PasswordAgeDays": 0,
+    "PasswordHistory": 0,
+    "PasswordComplexityRules": {
+      "RequireUppercase": true,
+      "RequireLowercase": true,
+      "RequireDigit": true,
+      "RequireSpecialChar": ""
+    }
+  },
+  "NewUserDefaultScopes": [
+    "devices:create",
+    "devices:delete",
+    "devices:read",
+    "devices:read-update",
+    "updates:read",
+    "updates:read-update",
+    "users:create",
+    "users:delete",
+    "users:read",
+    "users:read-update"
+  ]
+}
+EOF
+        chmod 0640 "${DATADIR}/auth/auth-config.json"
+
+        # Satisfy the complexity rules above deterministically rather than
+        # hoping a random string happens to contain every required class.
+        ADMIN_PW="Fio$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)1a"
+        PW_TMP="$(mktemp)"
+        printf '%s' "$ADMIN_PW" >"$PW_TMP"
+        aws secretsmanager put-secret-value \
+            --secret-id "$(secret_id admin-password)" \
+            --secret-string "file://${PW_TMP}" >/dev/null
+        rm -f "$PW_TMP"
+        log "escrowed the generated admin password"
+
+        "$FIOSERVER" --datadir "$DATADIR" user-add \
+            --username admin --password "$ADMIN_PW"
+        unset ADMIN_PW
+
+        # Escrow the generated config too. Terraform only seeds the
+        # auth-config secret when the operator passed auth_config_json, so
+        # without this a later restore (State B) would find it empty and have
+        # no auth config to install.
+        secret_put auth-config "${DATADIR}/auth/auth-config.json"
+    fi
+fi
+
+if [ ! -f "${DATADIR}/certs/tls.pem" ]; then
+    # --dnsname becomes the first DNS SAN of certs/tls.pem, and the server
+    # derives every device-facing URL from it (DgUrl is
+    # "https://<SAN>:8443", and each enrolled device's sota.toml is built from
+    # that). It must be the real public hostname, and it is effectively
+    # immutable once a device has enrolled.
+    #
+    # The expiry matters more than it looks: the gateway REFUSES TO START once
+    # this leaf expires, and nothing renews it automatically. Hence the
+    # long default.
+    log "running pki-init for ${GATEWAY_HOSTNAME} (factory ${FIOSERVER_FACTORY})"
+    "$FIOSERVER" --datadir "$DATADIR" pki-init \
+        --dnsname "$GATEWAY_HOSTNAME" \
+        --factory "$FIOSERVER_FACTORY" \
+        --tlsexpirydays "$TLS_EXPIRY_DAYS"
+fi
+
+if [ ! -f "${DATADIR}/tuf/keys/root.key" ]; then
+    log "running tuf-init"
+    "$FIOSERVER" --datadir "$DATADIR" tuf-init
+fi
+
+log "escrowing secrets to Secrets Manager"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+base64 -w0 <"${DATADIR}/auth/hmac.secret" >"${TMP}/hmac"
+secret_put hmac-secret "${TMP}/hmac"
+
+# Archive whole directories rather than individual keys. A restore needs more
+# than the roots of trust: devices authenticate against cas.pem and
+# device-ca.crt, and the TUF metadata chain must match the keys. pki-init
+# cannot rebuild a partial certs/ (AssertCleanPki refuses any pre-existing
+# file) and there is no re-issue-leaf subcommand, so a faithful restore means
+# keeping everything.
+tar -czf - -C "${DATADIR}" certs | base64 -w0 >"${TMP}/certs"
+secret_put certs-archive "${TMP}/certs"
+
+tar -czf - -C "${DATADIR}" tuf | base64 -w0 >"${TMP}/tuf"
+secret_put tuf-archive "${TMP}/tuf"
+
+echo "C $(date -u +%FT%TZ)" >"$MARKER"
+log "initialization complete"

--- a/contrib/terraform/aws/packer/files/fioserver-bootstrap.sh
+++ b/contrib/terraform/aws/packer/files/fioserver-bootstrap.sh
@@ -4,32 +4,20 @@
 #
 # First-boot bootstrap for the update server.
 #
-# Runs on EVERY boot (systemd oneshot) and picks one of three states. Choosing
+# Runs on EVERY boot (systemd oneshot) and picks one of two states. Choosing
 # the wrong state is the worst thing this script can do: re-running the init
 # commands on an already-provisioned server would mint a NEW TUF root key and
 # orphan every enrolled device. So the ordering of these tests matters, and the
 # cheapest, most local evidence (files on the data volume) is checked first.
 #
 #   State A  the data volume already holds a provisioned datadir  -> do nothing
-#   State B  the datadir is empty but secrets are escrowed        -> restore
-#   State C  no datadir and no escrow                             -> initialize
+#   State B  the datadir is empty and secrets are escrowed        -> restore
 #
-# Bootstrap ordering is dictated by the server itself:
-#   * auth-init writes ONLY auth/hmac.secret and no auth-config.json, and serve
-#     then fails in auth.NewProvider -> GetAuthConfig. So an auth-config.json
-#     must be supplied separately; that is what the auth-config secret is for.
-#   * InitHmacSecret() errors if auth/hmac.secret already exists.
-#   * tuf-init requires the HMAC secret to pre-exist (the TUF role keys are
-#     encrypted with a key derived from it via HKDF).
-#   * pki-init calls AssertCleanPki() and errors if ANY file in certs/ exists.
-# Each step below is therefore guarded by its own file test, so a crash midway
-# through State C leaves a resumable datadir rather than a wedged one.
 
 set -euo pipefail
 
 DATADIR=/data
 ENV_FILE=/etc/fioserver/env
-FIOSERVER=/usr/local/bin/fioserver
 MARKER="${DATADIR}/.bootstrap-state"
 
 log() { echo "bootstrap: $*"; }
@@ -39,45 +27,19 @@ die() { echo "bootstrap: ERROR: $*" >&2; exit 1; }
 # shellcheck disable=SC1090
 . "$ENV_FILE"
 
-: "${FIOSERVER_HOSTNAME:?must be set in $ENV_FILE}"
-: "${FIOSERVER_FACTORY:?must be set in $ENV_FILE}"
 : "${FIOSERVER_SECRET_PREFIX:?must be set in $ENV_FILE}"
 : "${AWS_REGION:?must be set in $ENV_FILE}"
-TLS_EXPIRY_DAYS="${FIOSERVER_TLS_EXPIRY_DAYS:-3650}"
-
-# Devices reach the gateway by a name that may differ from the UI's: with load
-# balancers the UI is behind an ALB and the gateway behind an NLB, and one DNS
-# record cannot alias to both. This is the name that goes into the certificate.
-GATEWAY_HOSTNAME="${FIOSERVER_GATEWAY_HOSTNAME:-$FIOSERVER_HOSTNAME}"
 
 export AWS_DEFAULT_REGION="$AWS_REGION"
 
 secret_id() { echo "${FIOSERVER_SECRET_PREFIX}/$1"; }
 
 # Print a secret's value, or nothing if it is absent/empty. A missing secret is
-# a normal, expected condition here (it is how State C is detected), so this
-# must not trip `set -e`.
+# how a not-yet-escrowed deployment is detected, so this must not trip `set -e`.
 secret_get() {
     aws secretsmanager get-secret-value \
         --secret-id "$(secret_id "$1")" \
         --query SecretString --output text 2>/dev/null || true
-}
-
-# Secrets Manager caps a secret at 64 KiB. certs/ and tuf/ hold only keys,
-# certificates and TUF metadata, so they are far below that -- but fail loudly
-# rather than let AWS truncate an escrow we may later need to restore from.
-secret_put() {
-    local name="$1" file="$2" size
-    size=$(wc -c <"$file")
-    if [ "$size" -gt 65536 ]; then
-        die "$name is ${size} bytes, over the 64KiB Secrets Manager limit"
-    fi
-    # file:// (not fileb://) -- these payloads are already base64 ASCII, and
-    # passing them via a file keeps them off the process command line.
-    aws secretsmanager put-secret-value \
-        --secret-id "$(secret_id "$name")" \
-        --secret-string "file://${file}" >/dev/null
-    log "escrowed $name (${size} bytes)"
 }
 
 mountpoint -q "$DATADIR" || die "$DATADIR is not a mount point"
@@ -92,165 +54,46 @@ if [ -f "${DATADIR}/tuf/keys/root.key" ] && [ -f "${DATADIR}/auth/hmac.secret" ]
 fi
 
 # ---------------------------------------------------------------- State B ----
-# Empty volume, but an escrow exists: this is a replacement instance or a
-# rebuild onto a fresh volume. Restore rather than re-initialize, so the
+# Empty volume, but an escrow exists: this is a replacement instance, a
+# rebuild onto a fresh volume, or the very first boot after
+# scripts/init-secrets.sh has run. Restore rather than generate, so the
 # factory identity and every enrolled device survive.
 HMAC_B64="$(secret_get hmac-secret)"
-if [ -n "$HMAC_B64" ]; then
-    log "escrow found; restoring PKI and TUF state from Secrets Manager"
-    install -d -m 0750 "${DATADIR}/auth" "${DATADIR}/certs" "${DATADIR}/tuf"
-
-    # The HMAC secret is 64 bytes of raw binary, so it is escrowed base64-encoded.
-    umask 077
-    echo "$HMAC_B64" | base64 -d >"${DATADIR}/auth/hmac.secret"
-    chmod 0600 "${DATADIR}/auth/hmac.secret"
-
-    AUTH_CONFIG="$(secret_get auth-config)"
-    if [ -n "$AUTH_CONFIG" ]; then
-        printf '%s' "$AUTH_CONFIG" >"${DATADIR}/auth/auth-config.json"
-    else
-        # Terraform only seeds this secret when the operator supplied
-        # auth_config_json. If it is empty, State C generated the config
-        # locally and escrowed it -- so an empty secret here means the escrow
-        # is incomplete, not that local auth was intended.
-        die "auth-config secret is empty; cannot restore"
-    fi
-    chmod 0640 "${DATADIR}/auth/auth-config.json"
-
-    # The archives are created with `tar -C $DATADIR certs` / `... tuf`, so
-    # their entries are already prefixed with the directory name. Extract at
-    # the datadir root, not into the directory itself.
-    for name in certs-archive tuf-archive; do
-        val="$(secret_get "$name")"
-        [ -n "$val" ] || die "$name secret is empty; cannot restore"
-        echo "$val" | base64 -d | tar -xzf - -C "$DATADIR"
-        log "restored $name"
-    done
-
-    # Re-assert restrictive modes: tar preserves them, but a hand-edited escrow
-    # might not.
-    find "${DATADIR}/certs" "${DATADIR}/tuf" -type f -name '*.key' -exec chmod 0600 {} +
-
-    # Deliberately NOT restored: db.sqlite. The escrow preserves the server's
-    # identity, not its data. If the volume was lost, recover the database from
-    # a DLM snapshot; otherwise device and update records are gone even though
-    # the PKI is intact.
-    log "restore complete (db.sqlite not restored; see the README)"
-    echo "B $(date -u +%FT%TZ)" >"$MARKER"
-    exit 0
+if [ -z "$HMAC_B64" ]; then
+    die "no provisioned datadir and no escrow in Secrets Manager;" \
+        "run contrib/terraform/aws/scripts/init-secrets.sh before this instance's first boot"
 fi
 
-# ---------------------------------------------------------------- State C ----
-# Genuinely first boot.
-log "no datadir and no escrow; initializing a new server"
+log "escrow found; restoring PKI and TUF state from Secrets Manager"
+install -d -m 0750 "${DATADIR}/auth" "${DATADIR}/certs" "${DATADIR}/tuf"
 
-if [ ! -f "${DATADIR}/auth/hmac.secret" ]; then
-    log "running auth-init"
-    "$FIOSERVER" --datadir "$DATADIR" auth-init
-fi
+# The HMAC secret is 64 bytes of raw binary, so it is escrowed base64-encoded.
+umask 077
+echo "$HMAC_B64" | base64 -d >"${DATADIR}/auth/hmac.secret"
+chmod 0600 "${DATADIR}/auth/hmac.secret"
 
-if [ ! -f "${DATADIR}/auth/auth-config.json" ]; then
-    AUTH_CONFIG="$(secret_get auth-config)"
-    if [ -n "$AUTH_CONFIG" ]; then
-        log "writing operator-supplied auth-config.json"
-        printf '%s' "$AUTH_CONFIG" >"${DATADIR}/auth/auth-config.json"
-        chmod 0640 "${DATADIR}/auth/auth-config.json"
-    else
-        log "no auth-config supplied; configuring local auth with a generated admin"
-        cat >"${DATADIR}/auth/auth-config.json" <<'EOF'
-{
-  "Type": "local",
-  "SessionTimeoutHours": 48,
-  "Config": {
-    "MinPasswordLength": 12,
-    "PasswordAgeDays": 0,
-    "PasswordHistory": 0,
-    "PasswordComplexityRules": {
-      "RequireUppercase": true,
-      "RequireLowercase": true,
-      "RequireDigit": true,
-      "RequireSpecialChar": ""
-    }
-  },
-  "NewUserDefaultScopes": [
-    "devices:create",
-    "devices:delete",
-    "devices:read",
-    "devices:read-update",
-    "updates:read",
-    "updates:read-update",
-    "users:create",
-    "users:delete",
-    "users:read",
-    "users:read-update"
-  ]
-}
-EOF
-        chmod 0640 "${DATADIR}/auth/auth-config.json"
+AUTH_CONFIG="$(secret_get auth-config)"
+[ -n "$AUTH_CONFIG" ] || die "auth-config secret is empty; cannot restore"
+printf '%s' "$AUTH_CONFIG" >"${DATADIR}/auth/auth-config.json"
+chmod 0640 "${DATADIR}/auth/auth-config.json"
 
-        # Satisfy the complexity rules above deterministically rather than
-        # hoping a random string happens to contain every required class.
-        ADMIN_PW="Fio$(openssl rand -base64 24 | tr -dc 'A-Za-z0-9' | head -c 24)1a"
-        PW_TMP="$(mktemp)"
-        printf '%s' "$ADMIN_PW" >"$PW_TMP"
-        aws secretsmanager put-secret-value \
-            --secret-id "$(secret_id admin-password)" \
-            --secret-string "file://${PW_TMP}" >/dev/null
-        rm -f "$PW_TMP"
-        log "escrowed the generated admin password"
+# The archives are created with `tar -C $DATADIR certs` / `... tuf`, so
+# their entries are already prefixed with the directory name. Extract at
+# the datadir root, not into the directory itself.
+for name in certs-archive tuf-archive; do
+    val="$(secret_get "$name")"
+    [ -n "$val" ] || die "$name secret is empty; cannot restore"
+    echo "$val" | base64 -d | tar -xzf - -C "$DATADIR"
+    log "restored $name"
+done
 
-        "$FIOSERVER" --datadir "$DATADIR" user-add \
-            --username admin --password "$ADMIN_PW"
-        unset ADMIN_PW
+# Re-assert restrictive modes: tar preserves them, but a hand-edited escrow
+# might not.
+find "${DATADIR}/certs" "${DATADIR}/tuf" -type f -name '*.key' -exec chmod 0600 {} +
 
-        # Escrow the generated config too. Terraform only seeds the
-        # auth-config secret when the operator passed auth_config_json, so
-        # without this a later restore (State B) would find it empty and have
-        # no auth config to install.
-        secret_put auth-config "${DATADIR}/auth/auth-config.json"
-    fi
-fi
-
-if [ ! -f "${DATADIR}/certs/tls.pem" ]; then
-    # --dnsname becomes the first DNS SAN of certs/tls.pem, and the server
-    # derives every device-facing URL from it (DgUrl is
-    # "https://<SAN>:8443", and each enrolled device's sota.toml is built from
-    # that). It must be the real public hostname, and it is effectively
-    # immutable once a device has enrolled.
-    #
-    # The expiry matters more than it looks: the gateway REFUSES TO START once
-    # this leaf expires, and nothing renews it automatically. Hence the
-    # long default.
-    log "running pki-init for ${GATEWAY_HOSTNAME} (factory ${FIOSERVER_FACTORY})"
-    "$FIOSERVER" --datadir "$DATADIR" pki-init \
-        --dnsname "$GATEWAY_HOSTNAME" \
-        --factory "$FIOSERVER_FACTORY" \
-        --tlsexpirydays "$TLS_EXPIRY_DAYS"
-fi
-
-if [ ! -f "${DATADIR}/tuf/keys/root.key" ]; then
-    log "running tuf-init"
-    "$FIOSERVER" --datadir "$DATADIR" tuf-init
-fi
-
-log "escrowing secrets to Secrets Manager"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
-
-base64 -w0 <"${DATADIR}/auth/hmac.secret" >"${TMP}/hmac"
-secret_put hmac-secret "${TMP}/hmac"
-
-# Archive whole directories rather than individual keys. A restore needs more
-# than the roots of trust: devices authenticate against cas.pem and
-# device-ca.crt, and the TUF metadata chain must match the keys. pki-init
-# cannot rebuild a partial certs/ (AssertCleanPki refuses any pre-existing
-# file) and there is no re-issue-leaf subcommand, so a faithful restore means
-# keeping everything.
-tar -czf - -C "${DATADIR}" certs | base64 -w0 >"${TMP}/certs"
-secret_put certs-archive "${TMP}/certs"
-
-tar -czf - -C "${DATADIR}" tuf | base64 -w0 >"${TMP}/tuf"
-secret_put tuf-archive "${TMP}/tuf"
-
-echo "C $(date -u +%FT%TZ)" >"$MARKER"
-log "initialization complete"
+# Deliberately NOT restored: db.sqlite. The escrow preserves the server's
+# identity, not its data. If the volume was lost, recover the database from
+# a DLM snapshot; otherwise device and update records are gone even though
+# the PKI is intact.
+log "restore complete (db.sqlite not restored; see the README)"
+echo "B $(date -u +%FT%TZ)" >"$MARKER"

--- a/contrib/terraform/aws/packer/files/fioserver-volume-init
+++ b/contrib/terraform/aws/packer/files/fioserver-volume-init
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Label the fioserver data volume, formatting it only if it is genuinely blank.
+#
+# Safety is the whole point of this script: it must never reformat a volume that
+# holds a provisioned datadir, because that would destroy the TUF root key and
+# the device PKI. So it only ever acts on a disk with NO filesystem signature at
+# all, and it bails out if that description matches more or less than one disk.
+
+set -euo pipefail
+
+LABEL=fiodata
+
+log() { echo "volume-init: $*"; }
+
+if [ -e "/dev/disk/by-label/${LABEL}" ]; then
+    log "/dev/disk/by-label/${LABEL} already exists; nothing to do"
+    exit 0
+fi
+
+# Identify the root disk so it is never a candidate.
+root_src="$(findmnt -no SOURCE / || true)"
+root_disk=""
+if [ -n "$root_src" ]; then
+    root_disk="$(lsblk -no PKNAME "$root_src" 2>/dev/null || true)"
+    [ -n "$root_disk" ] || root_disk="$(basename "$root_src")"
+fi
+
+candidates=()
+while read -r name type; do
+    [ "$type" = "disk" ] || continue
+    [ "$name" = "$root_disk" ] && continue
+    # Skip any disk that has partitions or a filesystem/RAID signature.
+    if [ -n "$(lsblk -no NAME "/dev/${name}" | tail -n +2)" ]; then
+        log "/dev/${name} has partitions; leaving it alone"
+        continue
+    fi
+    if blkid -p "/dev/${name}" >/dev/null 2>&1; then
+        log "/dev/${name} already has a signature; leaving it alone"
+        continue
+    fi
+    candidates+=("$name")
+done < <(lsblk -dno NAME,TYPE)
+
+if [ "${#candidates[@]}" -eq 0 ]; then
+    echo "volume-init: ERROR: no blank data disk found and no ${LABEL} label present" >&2
+    echo "volume-init: refusing to guess; inspect lsblk output on the instance" >&2
+    exit 1
+elif [ "${#candidates[@]}" -gt 1 ]; then
+    echo "volume-init: ERROR: multiple blank disks (${candidates[*]}); refusing to guess" >&2
+    exit 1
+fi
+
+dev="/dev/${candidates[0]}"
+log "formatting ${dev} as ext4 with label ${LABEL}"
+mkfs.ext4 -q -L "$LABEL" "$dev"
+udevadm settle
+log "done"

--- a/contrib/terraform/aws/packer/files/fioserver-volume-init.service
+++ b/contrib/terraform/aws/packer/files/fioserver-volume-init.service
@@ -1,0 +1,26 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Format the data volume on first attach, and only then.
+#
+# The volume is attached as /dev/sdf, but Nitro instances expose it as
+# /dev/nvme1n1 -- and the number depends on attachment order. Neither path is
+# stable, so this unit finds the one non-root disk that has no filesystem
+# signature, formats it with the label everything else keys off, and refuses to
+# touch anything that already carries data.
+
+[Unit]
+Description=Initialize the fioserver data volume
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
+Before=data.mount
+ConditionPathExists=!/dev/disk/by-label/fiodata
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/fioserver-volume-init
+
+[Install]
+WantedBy=local-fs.target

--- a/contrib/terraform/aws/packer/files/fioserver.service
+++ b/contrib/terraform/aws/packer/files/fioserver.service
@@ -6,8 +6,8 @@
 # The UI bind address comes from /etc/fioserver/env, because it differs by
 # topology: with a load balancer the ALB connects over the network, so the UI
 # must listen on 0.0.0.0; with Caddy in front it only ever needs loopback.
-# The gateway always binds 0.0.0.0:8443 -- it terminates mTLS itself and must
-# never sit behind an L7 proxy.
+# The gateway always binds 0.0.0.0:$FIOSERVER_GATEWAY_ADDR's port (8443 by
+# default) -- it terminates mTLS itself and must never sit behind an L7 proxy.
 
 [Unit]
 Description=Foundries update server

--- a/contrib/terraform/aws/packer/files/fioserver.service
+++ b/contrib/terraform/aws/packer/files/fioserver.service
@@ -1,0 +1,41 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# The update server itself.
+#
+# The UI bind address comes from /etc/fioserver/env, because it differs by
+# topology: with a load balancer the ALB connects over the network, so the UI
+# must listen on 0.0.0.0; with Caddy in front it only ever needs loopback.
+# The gateway always binds 0.0.0.0:8443 -- it terminates mTLS itself and must
+# never sit behind an L7 proxy.
+
+[Unit]
+Description=Foundries update server
+Requires=data.mount fioserver-bootstrap.service
+After=data.mount fioserver-bootstrap.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/fioserver/env
+ExecStart=/usr/local/bin/fioserver --datadir /data serve \
+    --uiaddr ${FIOSERVER_UI_ADDR} \
+    --gatewayaddr ${FIOSERVER_GATEWAY_ADDR}
+Restart=always
+RestartSec=5s
+
+# Hardening. ProtectSystem=strict makes the whole filesystem read-only for this
+# unit, which suits the read-only root image; /data is the only writable path it
+# needs.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+ReadWritePaths=/data
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/terraform/aws/packer/files/provision.sh
+++ b/contrib/terraform/aws/packer/files/provision.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Bake-time provisioning: install the server, the units, and then relocate every
+# mutable path so the root filesystem can be mounted read-only.
+#
+# Read-only root is a deliberate trade. It means OS patching is "rebuild the AMI
+# and replace the instance" rather than "apt upgrade in place" -- which is safe
+# here precisely because the data volume and the Secrets Manager escrow let a
+# replacement instance come back with the same identity. See the README.
+
+set -euo pipefail
+
+FIOSERVER_VERSION="$1"
+FIOSERVER_ARCH="$2"
+
+log() { echo "== $*"; }
+
+export DEBIAN_FRONTEND=noninteractive
+
+log "waiting for cloud-init so apt is not contended"
+cloud-init status --wait >/dev/null 2>&1 || true
+
+log "installing base packages"
+apt-get update -q
+apt-get install -y -q --no-install-recommends \
+    ca-certificates \
+    curl \
+    debian-keyring \
+    debian-archive-keyring \
+    apt-transport-https \
+    gnupg \
+    unzip \
+    openssl \
+    e2fsprogs
+
+log "configuring networking statically (cloud-init's netplan renderer needs a writable /etc/netplan, which the read-only root doesn't provide)"
+# Without this, ens5 comes up with no address at all: cloud-init's netplan.py
+# fails to write /etc/netplan/50-cloud-init.yaml (read-only root), so neither
+# netplan nor networkd ever configures the interface, and dhcpcd -- which also
+# can't persist its lease file -- races networkd for the same link. A static,
+# baked networkd unit plus disabling both of those removes the race entirely.
+install -d -m 0755 /etc/systemd/network
+cat > /etc/systemd/network/10-dhcp-en.network <<'EOF'
+[Match]
+Name=en* eth*
+
+[Network]
+DHCP=yes
+EOF
+systemctl enable systemd-networkd.service
+systemctl disable dhcpcd.service || true
+install -d -m 0755 /etc/cloud/cloud.cfg.d
+cat > /etc/cloud/cloud.cfg.d/99-fioserver.cfg <<'EOF'
+# Networking is handled entirely by the static networkd unit above; leave
+# cloud-init out of it so it doesn't fail trying to render netplan config
+# against a read-only /etc.
+network:
+  config: disabled
+EOF
+
+log "installing Caddy (enabled only in the no-load-balancer topology)"
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+    > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -q
+apt-get install -y -q --no-install-recommends caddy
+# Both topologies share one AMI; Terraform's user_data decides which of these
+# gets enabled at boot.
+systemctl disable caddy || true
+
+log "installing the AWS CLI v2"
+# Debian packages awscli v1; the bootstrap needs v2 semantics for Secrets
+# Manager, and hand-rolling SigV4 with curl would be far more fragile.
+case "$FIOSERVER_ARCH" in
+    amd64) awscli_arch=x86_64 ;;
+    arm64) awscli_arch=aarch64 ;;
+    *) echo "unsupported arch $FIOSERVER_ARCH" >&2; exit 1 ;;
+esac
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${awscli_arch}.zip" -o /tmp/awscli.zip
+unzip -q /tmp/awscli.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscli.zip /tmp/aws
+
+log "installing the SSM Agent"
+# The official Debian AMIs Packer builds on top of do not ship this agent, so
+# without it SSM Session Manager has nothing on the instance to connect to.
+case "$FIOSERVER_ARCH" in
+    amd64) ssm_arch=debian_amd64 ;;
+    arm64) ssm_arch=debian_arm64 ;;
+    *) echo "unsupported arch $FIOSERVER_ARCH" >&2; exit 1 ;;
+esac
+curl -fsSL "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${ssm_arch}/amazon-ssm-agent.deb" \
+    -o /tmp/amazon-ssm-agent.deb
+dpkg -i /tmp/amazon-ssm-agent.deb
+rm -f /tmp/amazon-ssm-agent.deb
+systemctl enable amazon-ssm-agent
+
+log "installing fioserver ${FIOSERVER_VERSION} (${FIOSERVER_ARCH})"
+# Releases publish bare, uncompressed binaries -- no tarball, no version in the
+# filename -- so the version has to come from the release tag in the URL.
+url="https://github.com/foundriesio/update-server/releases/download/${FIOSERVER_VERSION}/fioserver-linux-${FIOSERVER_ARCH}"
+curl -fsSL "$url" -o /usr/local/bin/fioserver
+chmod 0755 /usr/local/bin/fioserver
+/usr/local/bin/fioserver --datadir=/tmp version || true
+
+install -d -m 0755 /etc/fioserver
+{
+    echo "fioserver_version=${FIOSERVER_VERSION}"
+    echo "fioserver_arch=${FIOSERVER_ARCH}"
+    echo "fioserver_url=${url}"
+    echo "fioserver_sha256=$(sha256sum /usr/local/bin/fioserver | cut -d' ' -f1)"
+    echo "built_at=$(date -u +%FT%TZ)"
+} > /etc/fioserver/build-info
+
+log "installing units and scripts"
+install -m 0755 /tmp/files/fioserver-bootstrap.sh /usr/local/sbin/fioserver-bootstrap
+install -m 0755 /tmp/files/fioserver-volume-init /usr/local/sbin/fioserver-volume-init
+install -m 0644 /tmp/files/data.mount /etc/systemd/system/data.mount
+install -m 0644 /tmp/files/fioserver-volume-init.service /etc/systemd/system/
+install -m 0644 /tmp/files/fioserver-bootstrap.service /etc/systemd/system/
+install -m 0644 /tmp/files/fioserver.service /etc/systemd/system/
+install -d -m 0755 /data
+install -m 0644 /tmp/files/Caddyfile /etc/caddy/Caddyfile
+
+systemctl enable fioserver-volume-init.service
+systemctl enable data.mount
+systemctl enable fioserver-bootstrap.service
+systemctl enable fioserver.service
+
+# Caddy's certificates must outlive the instance, so they live on the data
+# volume. Symlinks are created at bake time; the targets appear when /data is
+# mounted, and caddy.service is ordered after data.mount by a drop-in below.
+rm -rf /var/lib/caddy
+ln -s /data/caddy/lib /var/lib/caddy
+install -d -m 0755 /etc/systemd/system/caddy.service.d
+cat > /etc/systemd/system/caddy.service.d/override.conf <<'EOF'
+[Unit]
+Requires=data.mount fioserver-bootstrap.service
+After=data.mount fioserver-bootstrap.service
+[Service]
+EnvironmentFile=/etc/fioserver/env
+ExecStartPre=+/bin/mkdir -p /data/caddy/lib /data/caddy/config
+ExecStartPre=+/bin/chown caddy:caddy /data/caddy /data/caddy/lib /data/caddy/config
+Environment=XDG_CONFIG_HOME=/data/caddy/config
+Environment=XDG_DATA_HOME=/data/caddy/lib
+EOF
+
+log "cleaning up"
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/files
+cloud-init clean --logs || true
+rm -f /etc/machine-id && touch /etc/machine-id
+rm -f /var/lib/systemd/random-seed
+
+log "provisioning complete"

--- a/contrib/terraform/aws/packer/fioserver.pkr.hcl
+++ b/contrib/terraform/aws/packer/fioserver.pkr.hcl
@@ -1,0 +1,127 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Builds the AMI that both Terraform examples deploy: Debian 13 plus the
+# fioserver release binary, the systemd units, and a read-only root filesystem.
+
+packer {
+  required_version = ">= 1.9.0"
+  required_plugins {
+    amazon = {
+      version = ">= 1.3.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to build the AMI in."
+  default     = "us-east-1"
+}
+
+variable "fioserver_version" {
+  type        = string
+  description = <<-EOT
+    Release tag to install, e.g. "v0.9.2". Required and deliberately not
+    defaulted to "latest": pinning it is what makes an AMI reproducible.
+  EOT
+}
+
+variable "architecture" {
+  type        = string
+  description = "Target architecture: amd64 or arm64."
+  default     = "amd64"
+
+  validation {
+    condition     = contains(["amd64", "arm64"], var.architecture)
+    error_message = "The architecture must be amd64 or arm64."
+  }
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Instance type used for the build itself (not the deployment)."
+  default     = ""
+}
+
+variable "ami_name_prefix" {
+  type        = string
+  description = "Prefix for the resulting AMI name."
+  default     = "fioserver"
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "Extra AWS account IDs to share the resulting AMI with."
+  default     = []
+}
+
+locals {
+  # Debian 13 (trixie) is published for both architectures by this account.
+  debian_owner  = "136693071363"
+  build_type    = var.instance_type != "" ? var.instance_type : (var.architecture == "arm64" ? "t4g.small" : "t3.small")
+  ssh_user      = "admin"
+  ami_timestamp = formatdate("YYYYMMDD-hhmmss", timestamp())
+}
+
+source "amazon-ebs" "fioserver" {
+  region        = var.region
+  instance_type = local.build_type
+  ssh_username  = local.ssh_user
+
+  source_ami_filter {
+    filters = {
+      name                = "debian-13-${var.architecture}-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = [local.debian_owner]
+    most_recent = true
+  }
+
+  ami_name        = "${var.ami_name_prefix}-${var.fioserver_version}-${var.architecture}-${local.ami_timestamp}"
+  ami_description = "Foundries update server ${var.fioserver_version} (${var.architecture}), read-only root"
+  ami_users       = var.ami_users
+
+  # The root volume only holds the OS; all state lives on the separate data
+  # volume Terraform attaches.
+  launch_block_device_mappings {
+    device_name           = "/dev/xvda"
+    volume_size           = 8
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  # Require IMDSv2 during the build too, matching the deployed instance.
+  imds_support = "v2.0"
+
+  tags = {
+    Name              = "${var.ami_name_prefix}-${var.fioserver_version}-${var.architecture}"
+    fioserver_version = var.fioserver_version
+    architecture      = var.architecture
+    source_ami        = "{{ .SourceAMI }}"
+    source_ami_name   = "{{ .SourceAMIName }}"
+    built_by          = "packer"
+  }
+}
+
+build {
+  name    = "fioserver"
+  sources = ["source.amazon-ebs.fioserver"]
+
+  provisioner "file" {
+    source      = "${path.root}/files"
+    destination = "/tmp/files"
+  }
+
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; sudo {{ .Path }} ${var.fioserver_version} ${var.architecture}"
+    script          = "${path.root}/files/provision.sh"
+  }
+
+  post-processor "manifest" {
+    output     = "${path.root}/manifest.json"
+    strip_path = true
+  }
+}

--- a/contrib/terraform/aws/scripts/init-secrets.sh
+++ b/contrib/terraform/aws/scripts/init-secrets.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Generates the update server's hmac secret, PKI (root CA, TLS cert, device
+# CA), and TUF keys locally, then escrows them in AWS Secrets Manager. This is
+# what the instance itself used to do on first boot; running it here instead
+# means the instance's IAM role never needs secretsmanager:PutSecretValue --
+# it only ever reads the escrow back (see fioserver-bootstrap.sh's State B).
+#
+# A ready-made auth-config.json is required (--auth-config-json): this script
+# does not generate a local-auth admin account for you. See docs/auth.md and
+# contrib/auth-config-{local,github,google}.json for templates -- copy one and
+# fill in a password/client secret to bootstrap a local admin user yourself.
+#
+# Run this once per deployment, BEFORE `terraform apply` -- it creates the
+# Secrets Manager containers itself, and the Terraform module looks them up
+# with a data source rather than creating them. Running `apply` first would
+# have it error out immediately at that lookup rather than succeed and let
+# the instance fail loudly at boot instead.
+#
+# The values passed here MUST match the corresponding Terraform variables
+# exactly -- they are how this script computes the same Secrets Manager
+# names and the same PKI/TUF identity Terraform expects the instance to
+# restore.
+
+set -euo pipefail
+
+FIOSERVER=fioserver
+NAME_PREFIX=fioserver
+HOSTNAME=""
+GATEWAY_HOSTNAME=""
+FACTORY=""
+TLS_EXPIRY_DAYS=3650
+AUTH_CONFIG_FILE=""
+REGION=""
+
+usage() {
+    cat <<'EOF'
+Usage: init-secrets.sh --hostname HOST --factory NAME --auth-config-json FILE [options]
+
+Required:
+  --hostname NAME           Must match var.hostname in terraform.tfvars.
+  --factory NAME            Must match var.factory in terraform.tfvars.
+  --auth-config-json FILE   Path to auth-config.json. See docs/auth.md and
+                             contrib/auth-config-{local,github,google}.json.
+
+Options:
+  --name-prefix NAME        Must match var.name_prefix (default: fioserver).
+  --gateway-hostname NAME   Must match var.gateway_hostname, if set. Defaults
+                             to --hostname, matching the Terraform default.
+  --tls-expiry-days N       Must match var.tls_expiry_days (default: 3650).
+  --fioserver PATH          Path to the fioserver binary that matches the
+                             version in the deployed AMI (default: fioserver
+                             on $PATH).
+  --region REGION           AWS region, if not already set via the
+                             environment or an AWS CLI profile.
+EOF
+}
+
+log() { echo "init-secrets: $*"; }
+die() { echo "init-secrets: ERROR: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --name-prefix) NAME_PREFIX="$2"; shift 2 ;;
+    --hostname) HOSTNAME="$2"; shift 2 ;;
+    --gateway-hostname) GATEWAY_HOSTNAME="$2"; shift 2 ;;
+    --factory) FACTORY="$2"; shift 2 ;;
+    --tls-expiry-days) TLS_EXPIRY_DAYS="$2"; shift 2 ;;
+    --auth-config-json) AUTH_CONFIG_FILE="$2"; shift 2 ;;
+    --fioserver) FIOSERVER="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    -h | --help) usage; exit 0 ;;
+    *) die "unrecognized argument: $1" ;;
+    esac
+done
+
+[ -n "$HOSTNAME" ] || { usage; die "--hostname is required"; }
+[ -n "$FACTORY" ] || { usage; die "--factory is required"; }
+[ -n "$AUTH_CONFIG_FILE" ] || { usage; die "--auth-config-json is required"; }
+[ -r "$AUTH_CONFIG_FILE" ] || die "cannot read $AUTH_CONFIG_FILE"
+[ -z "$GATEWAY_HOSTNAME" ] && GATEWAY_HOSTNAME="$HOSTNAME"
+
+command -v "$FIOSERVER" >/dev/null || die "fioserver binary not found: $FIOSERVER"
+command -v aws >/dev/null || die "AWS CLI not found"
+[ -n "$REGION" ] && export AWS_DEFAULT_REGION="$REGION"
+
+SECRET_PREFIX="${NAME_PREFIX}/${HOSTNAME}"
+
+secret_id() { echo "${SECRET_PREFIX}/$1"; }
+
+secret_exists() {
+    aws secretsmanager describe-secret --secret-id "$(secret_id "$1")" >/dev/null 2>&1
+}
+
+secret_ensure() {
+    local name="$1"
+    secret_exists "$name" && return 0
+    aws secretsmanager create-secret \
+        --name "$(secret_id "$name")" \
+        --description "Written by scripts/init-secrets.sh: $name" >/dev/null
+    log "created secret $(secret_id "$name")"
+}
+
+secret_put() {
+    local name="$1" file="$2" size
+    size=$(wc -c <"$file")
+    if [ "$size" -gt 65536 ]; then
+        die "$name is ${size} bytes, over the 64KiB Secrets Manager limit"
+    fi
+    # file:// (not fileb://) -- these payloads are already base64 ASCII, and
+    # passing them via a file keeps them off the process command line.
+    aws secretsmanager put-secret-value \
+        --secret-id "$(secret_id "$name")" \
+        --secret-string "file://${file}" >/dev/null
+    log "escrowed $name (${size} bytes)"
+}
+
+# Create the secret containers if they don't exist yet. This must happen
+# before `terraform apply` -- the module looks these up with a data source
+# rather than creating them, so `apply` fails fast if this script hasn't run.
+for name in hmac-secret certs-archive tuf-archive auth-config; do
+    secret_ensure "$name"
+done
+
+DATADIR="$(mktemp -d)"
+trap 'rm -rf "$DATADIR"' EXIT
+umask 077
+
+log "running auth-init"
+"$FIOSERVER" --datadir "$DATADIR" auth-init
+
+install -d -m 0750 "${DATADIR}/auth"
+cp "$AUTH_CONFIG_FILE" "${DATADIR}/auth/auth-config.json"
+chmod 0640 "${DATADIR}/auth/auth-config.json"
+
+log "running pki-init for ${GATEWAY_HOSTNAME} (factory ${FACTORY})"
+"$FIOSERVER" --datadir "$DATADIR" pki-init \
+    --dnsname "$GATEWAY_HOSTNAME" \
+    --factory "$FACTORY" \
+    --tlsexpirydays "$TLS_EXPIRY_DAYS"
+
+log "running tuf-init"
+"$FIOSERVER" --datadir "$DATADIR" tuf-init
+
+log "escrowing secrets to Secrets Manager under ${SECRET_PREFIX}/"
+
+base64 -w0 <"${DATADIR}/auth/hmac.secret" >"${DATADIR}/hmac.b64"
+secret_put hmac-secret "${DATADIR}/hmac.b64"
+
+secret_put auth-config "${DATADIR}/auth/auth-config.json"
+
+# Archive whole directories rather than individual keys. A restore needs more
+# than the roots of trust: devices authenticate against cas.pem and
+# device-ca.crt, and the TUF metadata chain must match the keys. pki-init
+# cannot rebuild a partial certs/ (AssertCleanPki refuses any pre-existing
+# file) and there is no re-issue-leaf subcommand, so a faithful restore means
+# keeping everything.
+tar -czf - -C "${DATADIR}" certs | base64 -w0 >"${DATADIR}/certs.b64"
+secret_put certs-archive "${DATADIR}/certs.b64"
+
+tar -czf - -C "${DATADIR}" tuf | base64 -w0 >"${DATADIR}/tuf.b64"
+secret_put tuf-archive "${DATADIR}/tuf.b64"
+
+log "done. The instance will restore this escrow on its next boot" \
+    "(or the next fioserver-bootstrap.service run)."

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,6 +1,20 @@
 # Production Guide
 
-## Enabling TLS
+## Deploying on AWS
+
+[contrib/terraform/aws](../contrib/terraform/aws) has Packer and Terraform
+recipes that automate a single-instance AWS deployment: an AMI holding the
+release binary, a persistent EBS volume for the `--datadir`, daily volume
+snapshots, and the irreplaceable secrets (`auth/hmac.secret`, the TUF keys
+and the device PKI) escrowed in AWS Secrets Manager so a replacement instance 
+keeps the same identity.
+
+It offers the choice to use AWS for load balancing or expose the VM directly
+to internet facing traffic.
+
+## Deploying Manually
+
+### Enabling TLS
 
 The "UI port", default 8080, serves unencrypted HTTP communications.
 When exposing this service to the internet, you will need to secure it
@@ -47,12 +61,12 @@ services:
       - ./data:/data
 ```
 
-## Backups
+### Backups
 
 The server stores all of its data under the `--datadir`. This can be
 backed up as needed.
 
-## HA Failover
+### HA Failover
 
 The server has a single SQLite database file, `<datadir>/db.sqlite`.
 You can use the [Litestream](https://litestream.io/) project to stream

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -137,7 +137,7 @@ Options:
 > imported role keys can be encrypted at rest.
 
 > **IMPORTANT:** A successful import generates a new root key at
-> `<datadir>/tufrepo/keys/root.key`. This key is encrypted at rest using the
+> `<datadir>/tuf/keys/root.key`. This key is encrypted at rest using the
 > HMAC secret at `<datadir>/auth/hmac.secret`, so you must back up BOTH files —
 > the `root.key` is useless without the `hmac.secret` needed to decrypt it.
 > Store copies of both somewhere safe immediately. If either file is lost it


### PR DESCRIPTION
This creates Terraform modules and example plans to deploy the update server in AWS. It provides the user two deployment options:

 * No load-balancers - use Caddy to expose the webui and manage TLS
 * Use EC2 load-balancers to expose the webui (ALB) and device-gateway(NLB)

The deployment includes logic for nightly backups as well as storing important deployment secrets into AWS Secret Manager to help reduce the likelihood of deleting a secret that is required for the fleet's lifetime.