### PR TITLE
ui: Include tip for DEVICE_API endpoint

### DIFF
--- a/server/ui/web/handlers_settings.go
+++ b/server/ui/web/handlers_settings.go
@@ -19,14 +19,16 @@ func (h handlers) settings(c echo.Context) error {
 
 	ctx := struct {
 		baseCtx
-		Tokens     []users.Token
-		ScopesList []string
-		LocalAuth  bool
+		Tokens       []users.Token
+		ScopesList   []string
+		LocalAuth    bool
+		DeviceApiUrl string
 	}{
-		baseCtx:    h.baseCtx(c, "Settings", "settings"),
-		Tokens:     tokens,
-		ScopesList: session.User.AllowedScopes.ToSlice(),
-		LocalAuth:  h.provider.Name() == "local",
+		baseCtx:      h.baseCtx(c, "Settings", "settings"),
+		Tokens:       tokens,
+		ScopesList:   session.User.AllowedScopes.ToSlice(),
+		LocalAuth:    h.provider.Name() == "local",
+		DeviceApiUrl: c.Scheme() + "://" + c.Request().Host + "/v1/devices",
 	}
 	return c.Render(http.StatusOK, "settings.html", ctx)
 }

--- a/server/ui/web/templates/settings.html
+++ b/server/ui/web/templates/settings.html
@@ -20,6 +20,10 @@
           {{end}}
         </ul>
       </fieldset>
+      <fieldset>
+        <legend><strong>Device API</strong> <i>(for fio-device-register)</i></legend>
+        <p>{{.DeviceApiUrl}}</p>
+      </fieldset>
 
     </section>
 


### PR DESCRIPTION
fio-device-register needs the user to set `--device-api`. This isn't totally obvious for a user. Showing this value in the settings is a way to cheat and likely get the user's attention: they'll need to go to the place to generate their API token and will probably see it.