### PR TITLE
ui: fail/panic when UI assets are Git-LFS pointer stubs

### DIFF
--- a/.github/workflows/contrib-test.yml
+++ b/.github/workflows/contrib-test.yml
@@ -18,6 +18,9 @@ jobs:
           go-version: '~1.24'
       - name: Clone the code
         uses: actions/checkout@v4
+        with:
+          # the server binary and its container build fail on LFS pointer stubs
+          lfs: true
 
       - name: Build and test devshell
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # e2e runs fioserver, which panics on LFS pointer stubs
+          lfs: true
 
       - name: Build environment
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,6 +18,9 @@ jobs:
           go-version: '~1.24'
       - name: Clone the code
         uses: actions/checkout@v4
+        with:
+          # templates.go panics on LFS pointer stubs
+          lfs: true
       - name: Run tests
         run: |
           wget -O gotestsum.tgz https://github.com/gotestyourself/gotestsum/releases/download/v1.13.0/gotestsum_1.13.0_linux_amd64.tar.gz

--- a/contrib/server/Dockerfile
+++ b/contrib/server/Dockerfile
@@ -11,6 +11,11 @@ COPY go.* ./
 RUN go mod download
 
 COPY . .
+# go:embed silently bakes Git-LFS pointer stubs into the binary
+RUN if grep -q "git-lfs.github.com/spec" server/ui/web/templates/pico_min_211.css; then \
+        echo "ERROR: LFS assets are pointer stubs - the web UI would be unstyled. Run 'git lfs pull' and rebuild." >&2; \
+        exit 1; \
+    fi
 RUN go build \
     --ldflags '-linkmode external -extldflags "-static"' \
     -o fioserver \

--- a/server/ui/web/templates/templates.go
+++ b/server/ui/web/templates/templates.go
@@ -4,6 +4,7 @@
 package templates
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -19,6 +20,22 @@ var Assets embed.FS
 var Templates *template.Template
 
 func init() {
+	// go:embed bakes in whatever bytes the checkout had; a clone without
+	// git-lfs leaves pointer stubs and an unstyled UI
+	entries, err := Assets.ReadDir(".")
+	if err != nil {
+		panic(err)
+	}
+	for _, e := range entries {
+		data, err := Assets.ReadFile(e.Name())
+		if err != nil {
+			panic(err)
+		}
+		if bytes.HasPrefix(data, []byte("version https://git-lfs.github.com/spec")) {
+			panic(fmt.Sprintf("UI asset %s is a Git-LFS pointer stub; run 'git lfs pull' and rebuild", e.Name()))
+		}
+	}
+
 	funcMap := template.FuncMap{
 		"map": func(kv ...any) (map[string]any, error) {
 			if len(kv)%2 != 0 {


### PR DESCRIPTION
The Pico CSS asset lives in Git-LFS and is baked into the binary with go:embed. A clone made without git-lfs embeds the pointer stub instead, and the UI renders unstyled with no indication why. Per review feedback, this now fails loudly instead of warning.

-  Refuse to start with a stubbed asset and fail the container image build early.
- Add the git-lfs setting to contrib-test, merge, and unit-test which would now fail/panic.