### PR TITLE
gitignore: Ignore the quick-start datadir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/swagger/*
 bin/*
 release/*
 .local-data
+/datadir/


### PR DESCRIPTION
Every quick-start example uses --datadir=./datadir, so following the guide inside a clone leaves the server's PKI keys, HMAC secret, and TUF root key as untracked files one `git add -A` away from being committed. Anchor to the repo root so a datadir elsewhere in the tree is not swallowed.