### PR TITLE
docs: Fixes and new guides from quick-start beta testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Follow the [Quick Start](./docs/quick-start.md) guide to get a server running in
 
 The server runs a complete web interface as well as command line tool, [fiocli](./docs/fiocli.md).
 
+## Migrating from FoundriesFactory
+
+If you have an existing Factory with provisioned devices, the [migration
+guide](./docs/migration.md) covers signing with your Factory PKI, importing your
+fleet's TUF root, and repointing devices at this server.
+
 ## Adding updates
 The update server uses a content format compatible with [Offline Updates](https://docs.foundries.io/96/user-guide/offline-update/offline-update.html)
 to serve devices their TUF, OSTree, and Container data. Before uploading,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ look with your own logo, favicon, and color scheme — no rebuild required.
 The [production guide](./docs/production.md) covers considerations when
 deploying the update server for production use.
 
+## Advanced topics
+
+The [advanced topics guide](./docs/advanced.md) covers custom listen
+addresses, certificate lifetimes, and manual device registration.
+
 ## Developing
 The project is a single Golang binary that can be built with:
 ```

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -2,13 +2,12 @@
 
 This directory contains tools useful for local development
 
-## perf-test
+## `auth-config-*.json`
 
-Self-contained Locust-based mTLS performance test that seeds and drives
-thousands of fake devices against the update server. See
-`perf-test/README.md`.
+Authentication provider sample configurations for GitHub, Google, and local
+username/password. See [configuring authentication](../docs/auth.md).
 
-## dev-shell
+## `dev-shell` / `Dockerfile.devshell`
 
 This script builds a container with all the required dependencies for
 developing on this code base and will drop you in a container with the
@@ -16,24 +15,16 @@ project source code mounted.
 
 ## docker-compose.yml
 
-This compose project will launch an update server that devices can
-communicate with. In order to use this you must first:
-```
- $ go run github.com/foundriesio/update-server/cmd/server create-csr \
-     --datadir .compose-server-data \
-     --dnsname <HOSTNAME> --factory <FACTORY>
- $ go run github.com/foundriesio/update-server/cmd/server \
-    --datadir .compose-server-data sign-csr \
-    --cakey <PATH TO FACTORY PKI>/factory_ca.key \
-    --cacert <PATH TO FACTORY PKI>/factory_ca.pem
- $ fioctl keys ca show --just-device-cas > .compose-server-data/certs/cas.pem
+This compose project builds and launches an update server that devices can
+communicate with, storing its state in `.compose-server-data/` at the
+repository root. See [Running in a Container](../docs/container.md) for
+setup and usage.
 
- $ go run github.com/foundriesio/update-server/cmd/server \
-    --datadir .compose-server-data auth-init
+## `e2e`
 
- $ go run github.com/foundriesio/update-server/cmd/server \
-    --datadir .compose-server-data tuf-init
-```
+An end-to-end test suite that exercises a real update server together with
+a real device client (`fioup`), driving update, config, and remote-action
+flows through both the `fiocli` CLI and the web UI. See `e2e/README.md`.
 
 ## gen-certs.sh / fake-device.py
 
@@ -44,7 +35,7 @@ have fake-devices connect to it.
 
 Example:
 ```
- $ ./contrib/gen-certs /tmp/server
+ $ ./contrib/gen-certs.sh /tmp/server
  $  go run github.com/foundriesio/update-server/cmd/server serve --datadir /tmp/server
 
  # From another terminal:
@@ -53,3 +44,24 @@ Example:
  {"Uuid":"04581446-DB43-43B1-BAC3-DBA7D1328AAC","PubKey":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD
 QgAE9M4irNPAcO+3N+UZdfqH6M86IhGg\nC1X2xPHpE1q1JkPnJUYnOtoLPrCVERAQqN/2gzeJG3nl7fqKHrbzNRixgA==\n-----END PUBLIC KEY-----\n","UpdateName":"","Deleted":false,"LastSeen":1754345526,"IsProd":false}
 ```
+
+## `perf-test`
+
+Self-contained Locust-based mTLS performance test that seeds and drives
+thousands of fake devices against the update server. See
+`perf-test/README.md`.
+
+## `run-local.sh`
+
+Stands up a local development server in one step, defaulting its datadir to
+`./.local-data`. See [running locally](../docs/run-locally.md).
+
+## Server
+
+The Dockerfile that builds the update server container image, used by
+`docker-compose.yml` and [Running in a Container](../docs/container.md).
+
+## Terraform
+
+Packer and Terraform recipes for a single-instance AWS deployment. See the
+[production guide](../docs/production.md).

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,72 @@
+# Advanced Topics
+
+## Custom Listen Addresses
+
+`serve` binds the web UI / REST API to `:8080` and the device gateway to
+`:8443` by default — on all interfaces. Both are configurable:
+
+```
+  ./fioserver --datadir=./datadir serve --uiaddr=127.0.0.1:8080 --gatewayaddr=:9443
+```
+
+Binding the UI to `127.0.0.1` keeps it reachable only from the local
+machine, which is worth considering with the "noauth" provider. The
+gateway must remain reachable by devices; it is protected by mTLS.
+
+> [!NOTE]
+> The gateway port is baked into the server URLs of the `sota.toml` returned by
+> device enrollment, so choose it before enrolling devices.
+
+## Certificate lifetimes
+
+The PKI commands accept validity periods in days:
+
+* `pki-init --tlsexpirydays` — server TLS certificate validity
+  (default 365).
+* `pki-init --caexpirydays` — root and device CA certificate validity
+  (default 7300).
+* `sign-csr --expirydays` — TLS certificate validity when signing locally
+  (default 365).
+
+## Device Registration
+
+The `POST /v1/devices` API signs a device CSR and returns the credentials plus a
+complete `sota.toml` — it is the same API used by fio-device-register-compatible
+tooling. To enroll a device without fio-device-register, first generate the
+device's key and CSR. The CN must be the device UUID and the OU must be your
+factory name:
+
+```
+  uuid=$(uuidgen)
+  openssl ecparam -genkey -name prime256v1 -out pkey.pem
+  openssl req -new -key pkey.pem -out device.csr -subj "/CN=${uuid}/OU=<FACTORY>"
+```
+
+Enroll it (with the "noauth" provider. Any `Authorization` value is accepted;
+see the [API guide](./api.md) for real tokens):
+
+```
+  jq -n --arg uuid "$uuid" --arg name my-device --arg hwid <HARDWARE-ID> \
+    --rawfile csr device.csr \
+    '{uuid: $uuid, name: $name, "hardware-id": $hwid, csr: $csr}' \
+  | curl -X POST http://localhost:8080/v1/devices \
+      -H "Authorization: Bearer <token>" \
+      -H "Content-Type: application/json" -d @- > response.json
+```
+
+The response holds three files. Install them, along with the private key,
+into `/var/sota` on the device:
+
+```
+  jq -r '."root.crt"'   response.json > root.crt
+  jq -r '."client.pem"' response.json > client.pem
+  jq -r '."sota.toml"'  response.json > sota.toml
+  # copy root.crt, client.pem, sota.toml, and pkey.pem to /var/sota/
+```
+
+The generated `sota.toml` already points `tls.server`, `provision.server`,
+`uptane.repo_server`, `pacman.ostree_server`, and
+`pacman.compose_apps_proxy` at this server's device gateway; no hand-editing
+is needed. The gateway URL comes from the TLS certificate's DNS name plus
+the gateway port, so the `--dnsname` given to `pki-init` must be resolvable
+by devices.

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,129 @@
+# Running in a Container
+
+This guide stands up an immediately usable update server in a Docker
+container. It is the container equivalent of the [Quick Start](./quick-start.md)
+evaluation flow: a self-signed PKI and the "noauth" provider. For production
+concerns (TLS termination, backups, failover) see the
+[production guide](./production.md).
+
+## Quick Launch with Docker Compose
+
+From a repository checkout,
+[contrib/docker-compose.yml](../contrib/docker-compose.yml) builds the image
+and runs the server with host networking, keeping its state in
+`.compose-server-data/` at the repository root. Initialize that state once,
+then bring the service up — all from the `contrib/` directory:
+
+```
+  cd contrib
+  docker compose run --rm server --datadir=/data pki-init --dnsname <HOSTNAME> --factory <FACTORY>
+  docker compose run --rm server --datadir=/data auth-init --test
+  docker compose run --rm server --datadir=/data tuf-init
+  docker compose up -d
+```
+
+The UI is at <http://localhost:8080/> and the device gateway listens on port
+8443. The service uses host networking, so both ports listen on all host
+interfaces — and with the "noauth" provider, anyone who can reach port 8080 has
+full access. To keep the UI local while testing, add `--uiaddr=127.0.0.1:8080`
+to the `command:` list in the compose file. See [One-Time
+Setup](#one-time-setup) for what `<HOSTNAME>` and `<FACTORY>` mean, and [Run the
+Server](#run-the-server) for enrolling devices. The rest of this guide performs
+the same steps with plain `docker` commands and a `datadir` location of your
+choosing.
+
+## Build the Image
+
+The repository includes a Dockerfile that produces a minimal image with the
+`fioserver` binary as its entrypoint:
+
+```
+  docker build -t update-server -f contrib/server/Dockerfile .
+```
+
+> [!NOTE]
+> This repository stores web UI assets in Git-LFS. If the repository was cloned
+> without git-lfs, the image build fails with an error naming the stubbed asset:
+> "run `git lfs pull` and rebuild". A server built outside the container from
+> such a checkout refuses to start with the same message.
+
+## One-Time Setup
+
+All server state lives in a `datadir` on the host, mounted into the
+container at `/data`. Initialize it once:
+
+```
+  mkdir -p datadir
+  docker run --rm -v $PWD/datadir:/data update-server \
+    --datadir=/data pki-init --dnsname <HOSTNAME> --factory <FACTORY>
+  docker run --rm -v $PWD/datadir:/data update-server \
+    --datadir=/data auth-init --test
+  docker run --rm -v $PWD/datadir:/data update-server \
+    --datadir=/data tuf-init
+```
+
+`<HOSTNAME>` is the DNS name devices will use to reach the host running the
+container. For purely local testing a made-up name (e.g. `local-server`)
+works — add it to `/etc/hosts` on any machine that connects.
+
+These are the same `pki-init`, `auth-init --test`, and `tuf-init` steps
+described in the [Quick Start](./quick-start.md); the notes there about
+backing up `tuf/keys/root.key` and `auth/hmac.secret` apply here too.
+
+### Using an Existing Factory PKI
+
+If you already have a FoundriesFactory PKI, replace the `pki-init` step with the
+CSR flow. Run through the container the same way:
+
+```
+  docker run --rm -v $PWD/datadir:/data update-server \
+    --datadir=/data create-csr --dnsname <HOSTNAME> --factory <FACTORY>
+```
+
+Sign `datadir/certs/tls.csr` as described in [Sign the
+Request](./migration.md#sign-the-request), saving the result as
+`datadir/certs/tls.pem`. Next grant your Factory devices access:
+
+```
+  fioctl keys ca show --just-device-cas > datadir/certs/cas.pem
+```
+
+> [!NOTE]
+> With a rootful Docker installation the files the container writes are owned by
+> root, so saving `tls.pem` and `cas.pem` into `datadir/certs` may require
+> `sudo`.
+
+## Run the Server
+
+```
+  docker run -d --name update-server \
+    -v $PWD/datadir:/data \
+    -p 8080:8080 -p 8443:8443 \
+    update-server --datadir=/data serve
+```
+
+You can browse the UI at <http://localhost:8080/>. The device gateway
+listens on port 8443. Devices can now be enrolled — follow
+[Enroll a Device](./quick-start.md#enroll-a-device) in the Quick Start.
+
+> [!NOTE]
+> The published ports accept connections on **all** host interfaces, not just
+> localhost; with the "noauth" provider anyone who can reach port 8080 has full
+> access. To keep the UI local while testing, publish it as `-p
+> 127.0.0.1:8080:8080`. Port 8443 is protected by mTLS and must stay reachable
+> by devices.
+
+Manage the container with the usual commands:
+
+```
+  docker logs -f update-server
+  docker stop update-server
+  docker start update-server
+```
+
+## See Also
+
+- [contrib/docker-compose.yml](../contrib/README.md) — a compose-based
+  developer setup using an existing factory PKI.
+- [Production guide](./production.md) — running behind a TLS-terminating
+  reverse proxy.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,136 @@
+# Migrating a FoundriesFactory Fleet
+
+This guide is for users with an existing FoundriesFactory® Factory with
+provisioned devices who want this server to take over device management and
+updates. Follow the [Quick Start](./quick-start.md), replacing two of its steps
+with the factory-aware versions below so that already-provisioned devices keep
+trusting the server:
+
+- **Configure Mutual TLS** → [Sign with your factory PKI](#sign-with-your-factory-pki)
+- **Initialize TUF** → [Importing the fleet's TUF root](#importing-the-fleets-tuf-root)
+
+Then [repoint existing devices](#repoint-existing-devices) at the new
+server.
+
+## Sign with Your Factory PKI
+
+Devices authenticate using mTLS and your FoundriesFactory PKI. You will
+need access to your [Factory CA](https://docs.foundries.io/latest/reference-manual/security/device-gateway.html)
+in order to create a TLS certificate for device-facing APIs.
+
+Use this flow in place of the Quick Start's `pki-init` step.
+
+### Create Certificate Signing Requests for TLS
+
+Devices need to trust the TLS connection they make to this server. In
+order to do this, you must create a CSR to be signed with the Factory
+root key:
+
+```
+  ./fioserver --datadir=./datadir create-csr --dnsname <HOSTNAME> --factory <FACTORY>
+```
+
+### Sign the Request
+
+There are two ways to sign the CSR, depending on where your Factory root key
+lives.
+
+On a **separate PKI machine**, Copy `datadir/certs/tls.csr` to the computer with
+your factory PKI. This file does not contain sensitive information, so it is
+safe to share as needed. From the Factory PKI directory run:
+
+```
+  fioctl keys ca sign --pki-dir <path to your factory pki> <path to tls.csr>
+```
+
+This command will print the contents of the certificate. Go back to the update
+server system and create the file `datadir/certs/tls.pem` with this content.
+
+**Locally with `sign-csr`.** If the Factory root key and certificate are
+available as files on this machine, the server can sign its own CSR:
+
+```
+  ./fioserver --datadir=./datadir sign-csr --cakey <root.key> --cacert <root.crt>
+```
+
+This writes `datadir/certs/tls.pem` directly.
+
+### Grant Access to Devices
+
+This service needs to know what devices can connect to it. To allow all valid
+Factory devices:
+```
+ fioctl keys ca show --just-device-cas > datadir/certs/cas.pem
+```
+
+Continue with the Quick Start's
+[Configure User Authentication](./quick-start.md#configure-user-authentication)
+step.
+
+## Importing the Fleet's TUF Root
+
+If you already have a fleet of devices provisioned against a Foundries.io
+Factory, initializing a brand new TUF root would leave those devices unable to
+validate metadata from this server. Instead, you can import the Factory's
+existing root of trust so that already-provisioned devices continue to trust
+updates.
+
+The import reads every version of the Factory's `root.json` from a tarball you
+provide, storing them so devices can walk the trust chain. It then generates a
+new root (version N+1) with fresh online keys for the `root`, `targets`,
+`snapshot`, and `timestamp` roles. The new root is signed by both the Factory's
+offline root key (proving continuity of trust) and the new root key.
+
+You will need:
+
+- The Factory's offline keys tarball (typically `offline-creds.tgz`),
+  which contains the offline root key used to sign the rotation.
+- A gzipped tarball containing all of the Factory's `root.json` files (e.g.
+  `1.root.json`, `2.root.json`, ...). See `fioctl keys tuf download-roots`.
+```
+  ./fioserver --datadir=./datadir tuf-init \
+    --import-keys ./offline-creds.tgz \
+    --import-roots ./roots.tgz
+```
+
+Options:
+
+- `--import-keys` — path to the fioctl offline keys tarball. Providing this
+  (or `--import-roots`) enables import mode.
+- `--import-roots` — path to a gzipped tarball containing all of the Factory's
+  `root.json` files. See `fioctl keys tuf download-roots`.
+
+> [!NOTE]
+> Like a plain `tuf-init`, importing requires `auth-init` to have been run
+> first, and the backup warning in the Quick Start's [Initialize
+> TUF](./quick-start.md#initialize-tuf) step applies to the newly generated root
+> key.
+
+## Repoint Existing Devices
+
+Already-provisioned devices keep their Factory-issued client certificates; the
+[Grant Access to Devices](#grant-access-to-devices) step is what lets them
+authenticate here. Each device's `/var/sota/sota.toml` must be updated to point
+its server settings at this server's device gateway:
+
+```
+[tls]
+server = "https://<HOSTNAME>:8443"
+
+[provision]
+server = "https://<HOSTNAME>:8443"
+
+[uptane]
+repo_server = "https://<HOSTNAME>:8443/repo"
+
+[pacman]
+ostree_server = "https://<HOSTNAME>:8443/ostree"
+compose_apps_proxy = "https://<HOSTNAME>:8443/app-proxy-url"
+```
+
+Because the server's TLS certificate is signed by the Factory root, devices
+continue to trust the connection with the `root.crt` they already have.
+
+New devices can be enrolled as described in the Quick Start's
+[Enroll a Device](./quick-start.md#enroll-a-device) section, or provisioned
+with images built per [How to build an Update](./build-an-update.md).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,6 +8,9 @@ Download the latest update server from:
 Save as `fioserver`.
 For Linux and Mac, make sure to `chmod +x fioserver`.
 
+To run the server in a Docker container instead, see
+[Running in a Container](./container.md).
+
 ## Configure Mutual TLS
 
 Devices authenticate with the server using mutual TLS. `pki-init` creates

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,11 +1,5 @@
 # Quick Start
 
-## Prerequisites
-
-Devices authenticate using mTLS and your FoundriesFactory® PKI. You will
-need access to your [Factory CA](https://docs.foundries.io/latest/reference-manual/security/device-gateway.html)
-in order to create a TLS certificate for device-facing APIs.
-
 ## Install
 Download the latest update server from:
 
@@ -16,19 +10,8 @@ For Linux and Mac, make sure to `chmod +x fioserver`.
 
 ## Configure Mutual TLS
 
-There are two ways to set up the mutual TLS certificates which are used by 
-devices to authenticate with this server:
-
-* **Bootstrap a new PKI from scratch** with `pki-init` — use this if you do
-  not already have a FoundriesFactory PKI (see below).
-* **Sign a CSR with an existing factory PKI** using `create-csr` and
-  `sign-csr` — use this if you already have a factory root key and device
-  CAs (see [Sign with an existing factory PKI](#sign-with-an-existing-factory-pki)).
-
-### Bootstrap a new PKI from scratch
-
-If you don't have a pre-existing factory PKI, `pki-init` creates everything
-in one step:
+Devices authenticate with the server using mutual TLS. `pki-init` creates
+everything needed in one step:
 
 ```
   ./fioserver --datadir=./datadir pki-init --dnsname <HOSTNAME> --factory <FACTORY>
@@ -42,42 +25,12 @@ This generates, under `datadir/certs`:
 * `cas.pem`, containing the device CA so devices can authenticate.
 
 Import `root.crt` into your devices' trust store so they trust the server's
-TLS certificate. You can then skip ahead to
-[Configure User Authentication](#configure-user-authentication).
+TLS certificate.
 
-### Sign with an existing factory PKI
-
-#### Creat Certificate Signing requests for TLS
-
-Devices need to trust the TLS connection they make to this server. In
-order to do this, you must create a CSR to be signed with the Factory
-root key:
-
-```
-  ./fioserver --datadir=./datadir create-csr --dnsname <HOSTNAME> --factory <FACTORY>
-```
-
-#### Sign the Request
-
-Copy `datadir/certs/tls.csr` to the computer with your factory PKI. This
-file does not contain sensitive information, so it is safe to share as
-needed. From the factory PKI directory run:
-
-```
-  fioctl keys ca sign --pki-dir <path to your factory pki> <path to tls.csr>
-```
-
-This command will print the contents of the certificate. The contents are
-not sensitive. Go back to the update server system and create the
-file `datadir/certs/tls.pem` with this content.
-
-#### Grant Access to Devices
-
-This service needs to know what devices can connect to it. You can allow
-all valid factory devices to connect with:
-```
- fioctl keys ca show --just-device-cas > datadir/certs/cas.pem
-```
+> [!NOTE]
+> If migrating an existing FoundriesFactory fleet, sign the server's TLS
+> certificate with your Factory PKI instead. See [Sign with your Factory
+> PKI](./migration.md#sign-with-your-factory-pki).
 
 ## Configure User Authentication
 
@@ -100,39 +53,6 @@ root metadata must be initialized:
   ./fioserver --datadir=./datadir tuf-init
 ```
 
-### Importing an existing fleet's TUF root
-
-If you already have a fleet of devices provisioned against a Foundries.io
-factory, initializing a brand new TUF root would leave those devices unable
-to validate metadata from this server. Instead, you can import the factory's
-existing root of trust so that already-provisioned devices continue to trust
-updates.
-
-The import reads every version of the factory's `root.json` from a tarball you
-provide, stores them so devices can walk the trust chain, and then generates a
-new root (version N+1) with fresh online keys for the `root`, `targets`,
-`snapshot`, and `timestamp` roles. The new root is signed by both the factory's
-offline root key (proving continuity of trust) and the new root key.
-
-You will need:
-
-* The factory's offline keys tarball (typically `offline-creds.tgz`),
-  which contains the offline root key used to sign the rotation.
-* A gzipped tarball containing all of the factory's `root.json` files (e.g.
-  `1.root.json`, `2.root.json`, ...). See `fioctl keys tuf show-root`.
-```
-  ./fioserver --datadir=./datadir tuf-init \
-    --import-keys ./offline-creds.tgz \
-    --import-roots ./roots.tgz
-```
-
-Options:
-
-* `--import-keys` — path to the fioctl offline keys tarball. Providing this
-  (or `--import-roots`) enables import mode.
-* `--import-roots` — path to a gzipped tarball containing all of the factory's
-  `root.json` files. See `fioctl keys tuf download-roots`.
-
 > [!NOTE]
 > `tuf-init` requires `auth-init` to have been run first — the TUF role keys are
 > encrypted at rest with the HMAC secret it creates.
@@ -145,6 +65,11 @@ Options:
 > copies of both somewhere safe immediately. If either file is lost it CANNOT be
 > recovered, and you will permanently lose the ability to rotate or manage your
 > TUF root of trust.
+
+> [!NOTE]
+> If you already have a fleet provisioned against a Foundries.io Factory, import
+> its existing TUF root instead of creating a new one. See [Importing the
+> fleet's TUF root](./migration.md#importing-the-fleets-tuf-root).
 
 ## Run the Server
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -152,12 +152,29 @@ Options:
 
 You can browse the UI at <http://localhost:8080/>
 
-Devices can now connect to the server.
-The `/var/sota/sota.toml` file has several "server" settings that need to point
-to this new server:
+Devices can now be enrolled.
 
-* `tls.server`
-* `provision.server`
-* `uptane.repo_server`
-* `pacman.ostree_server`
-* `pacman.compose_apps_proxy = "https://<HOSTNAME>:8443/app-proxy-url"`
+## Enroll a Device
+
+Devices authenticate with the server using Mutual TLS. Enrollment uses
+[fio-device-register](https://github.com/foundriesio/lmp-device-register), which
+is part of a Yocto Project build with the
+[meta-foundries](https://github.com/foundriesio/meta-foundries) components
+enabled (see [How to build an Update](./build-an-update.md)). Alternatively,
+[fioup](https://github.com/foundriesio/fioup/releases) can enroll a device. To
+enroll with fio-device-register, run this on the device:
+
+```
+  DEVICE_API=http://<HOSTNAME>:8080/v1/devices \
+  OAUTH_BASE=http://<HOSTNAME>:8080/oauth2 \
+  fio-device-register \
+    --factory <FACTORY> \
+    --name <device-name> \
+    --tags <tag>
+```
+
+`--factory` must match the Factory name given to `pki-init`.
+
+> [!NOTE]
+> The "noauth" provider does not validate tokens or their scopes. See the [API
+> guide](./api.md) for real tokens.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -133,16 +133,18 @@ Options:
 * `--import-roots` — path to a gzipped tarball containing all of the factory's
   `root.json` files. See `fioctl keys tuf download-roots`.
 
-> **Note:** `tuf-init` requires `auth-init` to have been run first so that the
-> imported role keys can be encrypted at rest.
+> [!NOTE]
+> `tuf-init` requires `auth-init` to have been run first — the TUF role keys are
+> encrypted at rest with the HMAC secret it creates.
 
-> **IMPORTANT:** A successful import generates a new root key at
-> `<datadir>/tuf/keys/root.key`. This key is encrypted at rest using the
-> HMAC secret at `<datadir>/auth/hmac.secret`, so you must back up BOTH files —
-> the `root.key` is useless without the `hmac.secret` needed to decrypt it.
-> Store copies of both somewhere safe immediately. If either file is lost it
-> CANNOT be recovered, and you will permanently lose the ability to rotate or
-> manage your TUF root of trust.
+> [!IMPORTANT]
+> A successful `tuf-init` generates a new root key at
+> `<datadir>/tuf/keys/root.key`. This key is encrypted at rest using the HMAC
+> secret at `<datadir>/auth/hmac.secret`, so you must back up BOTH files — the
+> `root.key` is useless without the `hmac.secret` needed to decrypt it. Store
+> copies of both somewhere safe immediately. If either file is lost it CANNOT be
+> recovered, and you will permanently lose the ability to rotate or manage your
+> TUF root of trust.
 
 ## Run the Server
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -106,3 +106,6 @@ enroll with fio-device-register, run this on the device:
 > [!NOTE]
 > The "noauth" provider does not validate tokens or their scopes. See the [API
 > guide](./api.md) for real tokens.
+
+To enroll a device without fio-device-register, see
+[Device Registration](./advanced.md#device-registration).

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -82,5 +82,7 @@ rm -rf ./.local-data
   See the [updates guide](./updates.md) for adding real update content.
 - **The gateway mTLS port (`:8443`) will not accept real devices.** The
   self-signed certificate is not trusted by actual FoundriesFactory devices.
-  Follow the [Quick Start](./quick-start.md) guide for a production-grade PKI
-  setup.
+  Follow the Quick Start's
+  [Configure Mutual TLS](./quick-start.md#configure-mutual-tls) step to set
+  up a real PKI, or the [migration guide](./migration.md) to sign with an
+  existing Factory PKI.

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -50,7 +50,9 @@ instead of `noauth`:
 ```
 
 This seeds an initial user (`admin` / `admin` by default) and prints the login
-URL at startup. **Dev-only — do not use in production.**
+URL at startup. **Dev-only — do not use in production.** The `local` provider
+and its configuration options are documented in
+[configuring authentication](./auth.md).
 
 Override the credentials via environment variables:
 


### PR DESCRIPTION
Doc fixes and new guides from walking the quick start as a new user.

* **quick-start** — clarify the tuf-init/auth-init ordering, and add device enrollment via
  fio-device-register (and mention fioup).
* **migration** (new) — FoundriesFactory-specific setup moved out of the
  quick start: factory-PKI signing, TUF root import, repointing devices.
* **container** (new) — run the server in Docker: image build, init,
  serve, compose quick launch; `contrib/README.md` becomes an index.
* **advanced** (new) — listen-address flags, certificate lifetimes, and
  manual device registration against `POST /v1/devices`.
* **run-locally** — link the local auth provider guide.