### PR TITLE
docs: Update device registration for fio-device-register

### DIFF
--- a/contrib/e2e/README.md
+++ b/contrib/e2e/README.md
@@ -71,7 +71,7 @@ make clean
 
 | Module | What it covers |
 | --- | --- |
-| `test_connection.py` | Sanity: a device checks in and appears in the server; `lmp-device-register`-style registration. |
+| `test_connection.py` | Sanity: a device checks in and appears in the server; `fio-device-register`-style registration. |
 | `test_fiocli.py` | `fiocli devices list/show`; pushing a config and confirming `fioup` applies it on the device. |
 | `test_remote_actions.py` | `fioup run-and-report`; verifying the result via CLI and the web UI, plus artifact download. |
 | `test_updates.py` | Uploading an OTA update artifact and finding it in `updates list`. |

--- a/docs/build-an-update.md
+++ b/docs/build-an-update.md
@@ -59,6 +59,9 @@ That's the directory referenced as `ostree_repo` throughout the
 
 ### Without FoundriesFactory (meta-foundries + QLI)
 
+In this flow the registration tool is meta-foundries' `fio-device-register`,
+configured with `FIO_DEVICE_API` the same way.
+
 <!-- TODO: document building the platform without a FoundriesFactory.-->
 
 ## Build Apps

--- a/server/ui/api/handlers_devices_create.go
+++ b/server/ui/api/handlers_devices_create.go
@@ -134,7 +134,7 @@ type DeviceCreateResponse struct {
 	SotaToml  string `json:"sota.toml"`
 }
 
-// @Summary Create device. Used by lmp-device-register compliant tooling
+// @Summary Create device. Used by fio-device-register compliant tooling
 // @Accept  json
 // @Produce json
 // @Param data body DeviceCreateRequest true "Device creation request"


### PR DESCRIPTION
meta-foundries renamed the registration tool to fio-device-register, configured through FIO_DEVICE_API; FoundriesFactory LmP builds keep lmp-device-register and LMP_DEVICE_API. Use each name in its own flow.