### PR TITLE
feat: add air live-reload config for local development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,16 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  # Reuses Makefile's LDFLAGS (embeds git-describe version string).
+  # Run contrib/run-local.sh once first to initialise the data dir.
+  # Env vars: DATADIR (default: ./.local-data), PORT, GWPORT.
+  cmd      = "make fioserver"
+  bin      = "bin/fioserver"
+  full_bin = "sh -c 'exec bin/fioserver --datadir ${DATADIR:-./.local-data} serve ${PORT:+--uiaddr :$PORT} ${GWPORT:+--gatewayaddr :$GWPORT}'"
+  include_ext = ["go", "html", "css"]
+  exclude_dir = ["tmp", "bin", ".local-data", "docs", "contrib", ".git", ".vscode"]
+  delay = 1000
+
+[screen]
+  clear_on_rebuild = true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/*
 release/*
 .local-data
 /datadir/
+tmp/

--- a/docs/run-locally.md
+++ b/docs/run-locally.md
@@ -18,6 +18,41 @@ PKI, and no real devices. Intended for local development and UI exploration only
 
 `datadir` defaults to `./.local-data`.
 
+## Live reload for development
+
+Install `air` once:
+
+```
+go install github.com/air-verse/air@latest
+```
+
+Run `run-local.sh` once to initialise the data directory, then use `air` for all
+subsequent development. On any change to `*.go`, `*.html`, or `*.css`, `air`
+rebuilds the binary and restarts the server automatically.
+
+```
+# first time: initialise .local-data
+./contrib/run-local.sh
+
+# all subsequent runs
+air
+```
+
+The same environment variables as `run-local.sh` are accepted:
+
+| Variable  | Default          | Effect                             |
+|-----------|------------------|------------------------------------|
+| `DATADIR` | `./.local-data`  | Path to the data directory         |
+| `PORT`    | *(server default)* | UI listen address (`--uiaddr`)   |
+| `GWPORT`  | *(server default)* | Gateway address (`--gatewayaddr`) |
+
+```
+DATADIR=/tmp/mydata PORT=9090 GWPORT=9091 air
+```
+
+`air` manages the server process only; initialisation (`auth-init`, `tuf-init`,
+seeding) must be done via `run-local.sh`.
+
 ## What it does
 
 - Builds `bin/fioserver` from source.


### PR DESCRIPTION
Watches *.go, *.html, and *.css; rebuilds via make fioserver and
restarts the server automatically. Run contrib/run-local.sh once
first to initialise .local-data, then use `air` in place of
manual rebuild+restart cycles.

air must be installed first:

go install github.com/air-verse/air@latest

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Milo Casagrande <mcasagra@qti.qualcomm.com>
